### PR TITLE
[feat] 로그인 API 및 회원가입 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,9 @@ repositories {
 
 dependencies {
     // Spring
-    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     // Lombok
@@ -36,6 +37,7 @@ dependencies {
 
     // DB
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.session:spring-session-data-redis'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
     // Test Container

--- a/src/main/java/com/flytrap/venusplanner/api/auth_member/business/service/AuthMemberService.java
+++ b/src/main/java/com/flytrap/venusplanner/api/auth_member/business/service/AuthMemberService.java
@@ -6,14 +6,17 @@ import com.flytrap.venusplanner.api.auth_member.presentation.dto.LoginDto;
 import com.flytrap.venusplanner.global.auth.infrastructure.api.OAuthProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AuthMemberService {
 
     private final OAuthProvider oAuthProvider;
     private final MemberRepository memberRepository;
 
+    @Transactional
     public Member authenticateAndFetchMember(LoginDto.Request request) {
 
         var userResource = oAuthProvider.authenticateAndFetchMember(request.code());

--- a/src/main/java/com/flytrap/venusplanner/api/auth_member/business/service/AuthMemberService.java
+++ b/src/main/java/com/flytrap/venusplanner/api/auth_member/business/service/AuthMemberService.java
@@ -1,0 +1,27 @@
+package com.flytrap.venusplanner.api.auth_member.business.service;
+
+import com.flytrap.venusplanner.api.member.infrastructure.repository.MemberRepository;
+import com.flytrap.venusplanner.api.member.domain.Member;
+import com.flytrap.venusplanner.api.auth_member.presentation.dto.LoginDto;
+import com.flytrap.venusplanner.global.auth.infrastructure.api.OAuthProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthMemberService {
+
+    private final OAuthProvider oAuthProvider;
+    private final MemberRepository memberRepository;
+
+    public Member authenticateAndFetchMember(LoginDto.Request request) {
+
+        var userResource = oAuthProvider.authenticateAndFetchMember(request.code());
+        var authenticatedMember = memberRepository.findByOauthPk(userResource.oauthPk())
+                .orElse(Member.from(userResource));
+
+        memberRepository.save(authenticatedMember);
+
+        return authenticatedMember;
+    }
+}

--- a/src/main/java/com/flytrap/venusplanner/api/auth_member/business/service/AuthMemberService.java
+++ b/src/main/java/com/flytrap/venusplanner/api/auth_member/business/service/AuthMemberService.java
@@ -19,7 +19,7 @@ public class AuthMemberService {
     @Transactional
     public Member authenticateAndFetchMember(LoginDto.Request request) {
 
-        var userResource = oAuthProvider.authenticateAndFetchMember(request.code());
+        var userResource = oAuthProvider.authenticateAndFetchUserResource(request.code());
         var authenticatedMember = memberRepository.findByOauthPk(userResource.oauthPk())
                 .orElse(Member.from(userResource));
 

--- a/src/main/java/com/flytrap/venusplanner/api/auth_member/presentation/controller/AuthMemberController.java
+++ b/src/main/java/com/flytrap/venusplanner/api/auth_member/presentation/controller/AuthMemberController.java
@@ -1,0 +1,32 @@
+package com.flytrap.venusplanner.api.auth_member.presentation.controller;
+
+import com.flytrap.venusplanner.api.auth_member.business.service.AuthMemberService;
+import com.flytrap.venusplanner.api.auth_member.presentation.dto.LoginDto;
+import com.flytrap.venusplanner.api.auth_member.presentation.dto.SessionMember;
+import com.flytrap.venusplanner.api.member.domain.Member;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class AuthMemberController {
+
+    private final AuthMemberService authMemberService;
+
+    @PostMapping("/auth/sign-in")
+    public ResponseEntity<LoginDto.Response> signIn(
+            @RequestBody LoginDto.Request request,
+            HttpSession session
+    ) {
+        Member member = authMemberService.authenticateAndFetchMember(request);
+        session.setAttribute("SESSION_NAME", SessionMember.from(member));
+
+        return ResponseEntity.ok().body(LoginDto.Response.from(member));
+    }
+}

--- a/src/main/java/com/flytrap/venusplanner/api/auth_member/presentation/dto/LoginDto.java
+++ b/src/main/java/com/flytrap/venusplanner/api/auth_member/presentation/dto/LoginDto.java
@@ -1,0 +1,25 @@
+package com.flytrap.venusplanner.api.auth_member.presentation.dto;
+
+import com.flytrap.venusplanner.api.member.domain.Member;
+
+public class LoginDto {
+
+    public record Request(
+            String code
+    ) {
+    }
+
+    public record Response(
+            String email,
+            String profileUrl,
+            String nickName
+    ) {
+        public static Response from(Member member) {
+            return new Response(
+                    member.getEmail(),
+                    member.getProfileImageUrl(),
+                    member.getNickname()
+            );
+        }
+    }
+}

--- a/src/main/java/com/flytrap/venusplanner/api/auth_member/presentation/dto/SessionMember.java
+++ b/src/main/java/com/flytrap/venusplanner/api/auth_member/presentation/dto/SessionMember.java
@@ -1,0 +1,17 @@
+package com.flytrap.venusplanner.api.auth_member.presentation.dto;
+
+import com.flytrap.venusplanner.api.member.domain.Member;
+import java.io.Serializable;
+
+/**
+ * 로그인 후 Session에 저장되는 Member DTO입니다.
+ * @param id Member의 id값
+ */
+public record SessionMember (
+        long id
+) implements Serializable {
+
+    public static SessionMember from(Member member) {
+        return new SessionMember(member.getId());
+    }
+}

--- a/src/main/java/com/flytrap/venusplanner/api/member/domain/Member.java
+++ b/src/main/java/com/flytrap/venusplanner/api/member/domain/Member.java
@@ -1,0 +1,41 @@
+package com.flytrap.venusplanner.api.member.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String oauthPk;
+    private Long oauthPlatformId;
+    private String email;
+    private String profileImageUrl;
+    private String nickname;
+
+    @CreationTimestamp
+    private Instant createdTime;
+
+    @Builder
+    public Member(String oauthPk, Long oauthPlatformId, String email, String profileImageUrl, String nickname) {
+        this.oauthPk = oauthPk;
+        this.oauthPlatformId = oauthPlatformId;
+        this.email = email;
+        this.profileImageUrl = profileImageUrl;
+        this.nickname = nickname;
+    }
+
+}

--- a/src/main/java/com/flytrap/venusplanner/api/member/domain/Member.java
+++ b/src/main/java/com/flytrap/venusplanner/api/member/domain/Member.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -21,10 +22,19 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @NotNull
     private String oauthPk;
+
+    @NotNull
     private Long oauthPlatformId;
+
+    @NotNull
     private String email;
+
+    @NotNull
     private String profileImageUrl;
+
+    @NotNull
     private String nickname;
 
     @CreationTimestamp

--- a/src/main/java/com/flytrap/venusplanner/api/member/domain/Member.java
+++ b/src/main/java/com/flytrap/venusplanner/api/member/domain/Member.java
@@ -1,5 +1,6 @@
 package com.flytrap.venusplanner.api.member.domain;
 
+import com.flytrap.venusplanner.global.auth.infrastructure.dto.StandardizedUserResource;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -38,4 +39,13 @@ public class Member {
         this.nickname = nickname;
     }
 
+    public static Member from(StandardizedUserResource userResource) {
+        return Member.builder()
+                .oauthPk(userResource.oauthPk())
+                .oauthPlatformId(userResource.authPlatformType().getId())
+                .email(userResource.email())
+                .profileImageUrl(userResource.profileUrl())
+                .nickname(userResource.nickname())
+                .build();
+    }
 }

--- a/src/main/java/com/flytrap/venusplanner/api/member/domain/OAuthPlatform.java
+++ b/src/main/java/com/flytrap/venusplanner/api/member/domain/OAuthPlatform.java
@@ -1,0 +1,23 @@
+package com.flytrap.venusplanner.api.member.domain;
+
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OAuthPlatform {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Convert(converter = OAuthPlatformTypeConverter.class)
+    private OAuthPlatformType name;
+}

--- a/src/main/java/com/flytrap/venusplanner/api/member/domain/OAuthPlatformType.java
+++ b/src/main/java/com/flytrap/venusplanner/api/member/domain/OAuthPlatformType.java
@@ -1,0 +1,23 @@
+package com.flytrap.venusplanner.api.member.domain;
+
+import com.flytrap.venusplanner.api.member.exception.UnknownOAuthPlatformType;
+import java.util.Arrays;
+import java.util.Objects;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OAuthPlatformType {
+    GITHUB(1L);
+
+    private final Long id;
+
+    public static OAuthPlatformType fromName(String name) {
+        return Arrays.stream(OAuthPlatformType.values())
+                .filter(type -> Objects.equals(type.name(), name))
+                .findFirst()
+                .orElseThrow(() -> new UnknownOAuthPlatformType(name));
+    }
+
+}

--- a/src/main/java/com/flytrap/venusplanner/api/member/domain/OAuthPlatformTypeConverter.java
+++ b/src/main/java/com/flytrap/venusplanner/api/member/domain/OAuthPlatformTypeConverter.java
@@ -1,0 +1,24 @@
+package com.flytrap.venusplanner.api.member.domain;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class OAuthPlatformTypeConverter implements AttributeConverter<OAuthPlatformType, String> {
+
+    @Override
+    public String convertToDatabaseColumn(OAuthPlatformType type) {
+        if (type == null) {
+            return null;
+        }
+        return type.name();
+    }
+
+    @Override
+    public OAuthPlatformType convertToEntityAttribute(String dbData) {
+        if (dbData == null) {
+            return null;
+        }
+        return OAuthPlatformType.fromName(dbData);
+    }
+}

--- a/src/main/java/com/flytrap/venusplanner/api/member/exception/UnknownOAuthPlatformType.java
+++ b/src/main/java/com/flytrap/venusplanner/api/member/exception/UnknownOAuthPlatformType.java
@@ -1,0 +1,7 @@
+package com.flytrap.venusplanner.api.member.exception;
+
+public class UnknownOAuthPlatformType extends RuntimeException {
+    public UnknownOAuthPlatformType(String typeName) {
+        super(typeName + "은(는) 알 수 없는 플랫폼 명 입니다.");
+    }
+}

--- a/src/main/java/com/flytrap/venusplanner/api/member/infrastructure/repository/MemberRepository.java
+++ b/src/main/java/com/flytrap/venusplanner/api/member/infrastructure/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.flytrap.venusplanner.api.member.infrastructure.repository;
+
+import com.flytrap.venusplanner.api.member.domain.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByOauthPk(String oauthPk);
+}

--- a/src/main/java/com/flytrap/venusplanner/global/auth/infrastructure/api/OAuthProvider.java
+++ b/src/main/java/com/flytrap/venusplanner/global/auth/infrastructure/api/OAuthProvider.java
@@ -4,5 +4,5 @@ import com.flytrap.venusplanner.global.auth.infrastructure.dto.StandardizedUserR
 
 public interface OAuthProvider {
 
-    StandardizedUserResource authenticateAndFetchMember(String code);
+    StandardizedUserResource authenticateAndFetchUserResource(String code);
 }

--- a/src/main/java/com/flytrap/venusplanner/global/auth/infrastructure/api/OAuthProvider.java
+++ b/src/main/java/com/flytrap/venusplanner/global/auth/infrastructure/api/OAuthProvider.java
@@ -1,0 +1,8 @@
+package com.flytrap.venusplanner.global.auth.infrastructure.api;
+
+import com.flytrap.venusplanner.global.auth.infrastructure.dto.StandardizedUserResource;
+
+public interface OAuthProvider {
+
+    StandardizedUserResource authenticateAndFetchMember(String code);
+}

--- a/src/main/java/com/flytrap/venusplanner/global/auth/infrastructure/dto/StandardizedUserResource.java
+++ b/src/main/java/com/flytrap/venusplanner/global/auth/infrastructure/dto/StandardizedUserResource.java
@@ -1,0 +1,13 @@
+package com.flytrap.venusplanner.global.auth.infrastructure.dto;
+
+import com.flytrap.venusplanner.api.member.domain.OAuthPlatformType;
+
+public record StandardizedUserResource(
+        String oauthPk,
+        String email,
+        String nickname,
+        String profileUrl,
+        OAuthPlatformType authPlatformType
+) {
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,5 +4,6 @@ spring:
     group:
       local: [ local ] # localhost
       prod: [ prod ] # aws ec2
+    include: [ auth ]
   jpa:
     open-in-view: false

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -18,11 +18,19 @@ CREATE TABLE `member_study`
 
 CREATE TABLE `member`
 (
-    `id`           BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY,
-    `sign_type`    BIGINT       NOT NULL,
-    `email`        VARCHAR(255) NOT NULL COMMENT 'OAuth 아이디 (이메일 형식)',
-    `nickname`     VARCHAR(50)  NOT NULL COMMENT 'OAuth 이름(닉네임)',
-    `created_time` TIMESTAMP    NOT NULL
+    `id`                BIGINT          NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `oauth_pk`          VARCHAR(100)    NOT NULL,
+    `oauth_platform_id` BIGINT          NOT NULL,
+    `email`             VARCHAR(255)    NOT NULL COMMENT 'OAuth 아이디 (이메일 형식)',
+    `profile_image_url` VARCHAR(2500)   NULL,
+    `nickname`          VARCHAR(50)     NOT NULL COMMENT 'OAuth 이름(닉네임)',
+    `created_time`      TIMESTAMP       NOT NULL
+);
+
+CREATE TABLE `oauth_platform`
+(
+    `id`   BIGINT       NOT NULL,
+    `name` VARCHAR(10)  NULL
 );
 
 CREATE TABLE `study`


### PR DESCRIPTION
# ✨ Key changes
- [ ] #2 
  
# 👋 To reviewers
## 로그인 및 회원가입 과정
```mermaid
sequenceDiagram
    actor User
    
    box rgb(255, 255, 153) React Front Server
    participant Front Page
    end
    
    box rgb(191, 223, 255) OAuth Server
    participant OAuth Server
    end
    
    box rgb(204, 255, 153) SpringBoot API Server
    participant AuthMemberController
    participant AuthMemberService
    participant OAuthProvider
    participant MemberEntityRepository
    end
    
    box rgb(255,102,102) Session Cluster
    participant Redis
    end
    
    User ->>+ Front Page: 로그인 버튼 클릭
    Front Page ->>+ OAuth Server: 인증 요청
    OAuth Server -->>- Front Page: 인증 code 전송
    Front Page ->>+ AuthMemberController: 인증 code와 함께 로그인 API 요청
    
    AuthMemberController ->>+ AuthMemberService: authenticateAndFetchMember(code)<br/>: OAuth 회원 인증 및 Member 불러오기
    
    AuthMemberService ->>+ OAuthProvider: authenticateAndFetchUserResource(code)<br/>: OAuth 회원 인증 및 유저 정보 불러오기
    OAuthProvider ->>+ OAuth Server: 유저 정보 요청
    OAuth Server -->>- OAuthProvider: 유저 정보 반환[OAuthPk, 이메일, 닉네임, 프로필 이미지]
    OAuthProvider -->>- AuthMemberService: 유저 정보를 StandardizedUserResource 객체로 반환
    
    AuthMemberService ->>+ MemberEntityRepository: findByOauthPk()<br/>: OAuth PK 값으로 유저 조회
        MemberEntityRepository -->>- AuthMemberService:Member 객체(DB에서 조회한 유저 정보) 반환
    alt if Member is NULL(신규 유저인 경우)
        AuthMemberService --> AuthMemberService: 새로운 Member 생성
    else if Member already EXIST(기존 유저인 경우)
        AuthMemberService --> AuthMemberService: Member UPDATE
    end
    AuthMemberService ->> MemberEntityRepository: Member DB에 저장(회원 가입)
    AuthMemberService -->>- AuthMemberController: Member 객체(DB에서 조회한 유저 정보) 반환
    AuthMemberController ->> Redis: HTTP Session 생성 및 HTTP Session 저장
    AuthMemberController -->>- Front Page: 뷰단에서 쓰일 유저 정보 반환
    
    Front Page -->>- User: 로그인된 화면을 볼 수 있다.
```
- 구현하게 될 로그인, 회원가입 로직입니다.
- 회원가입은 최초 OAuth 로그인을 하면 자동으로 진행됩니다.
- OAuth Server에 유저 정보를 요청하는 OAuthProvider는 다음 PR에서 구현했습니다. 이번 PR에서는 interface만 작성되어 있습니다.

## Member 관련 DB 스키마가 변경되었습니다
### 변경 전
<img width="558" alt="1" src="https://github.com/FlytrapHub/venus-planner-be/assets/86359180/d5f2e53e-8a4f-468b-9115-7550820c8db6">

### 변경 후
<img width="1037" alt="SCR-20240301-npyl" src="https://github.com/FlytrapHub/venus-planner-be/assets/86359180/6043d64d-8144-4b72-93ab-bd9ef7e749a2">

- `oauth_platform`: OAuth 기능을 제공해주는 플랫폼을 저장합니다. (e.g. GitHub, Kakao, Google ...)
- `oauth_pk`: OAuth 서버에서 회원을 구별하는 pk값을 저장하는 컬럼입니다.

## 패키지 구조
```text
- api
  - auth_member : 로그인, 로그아웃 API 관련 패키지
  - member : Member 도메인 관련 패키지
- global
  - auth : ArgumentResolver, OAuth 외부 API 관련 패키지
```