### PR TITLE
[feat] 로그인 로직에 GitHub OAuth 인증 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ out/
 ### VS Code ###
 .vscode/
 /gradle/wrapper/gradle-wrapper.jar
+/src/main/resources/application-auth.yml
+/src/main/resources/application-oauth-local.yml

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/flytrap/venusplanner/VenusPlannerApplication.java
+++ b/src/main/java/com/flytrap/venusplanner/VenusPlannerApplication.java
@@ -2,8 +2,10 @@ package com.flytrap.venusplanner;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class VenusPlannerApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/flytrap/venusplanner/api/auth_member/business/service/AuthMemberService.java
+++ b/src/main/java/com/flytrap/venusplanner/api/auth_member/business/service/AuthMemberService.java
@@ -20,6 +20,7 @@ public class AuthMemberService {
     public Member authenticateAndFetchMember(LoginDto.Request request) {
 
         var userResource = oAuthProvider.authenticateAndFetchUserResource(request.code());
+
         var authenticatedMember = memberRepository.findByOauthPk(userResource.oauthPk())
                 .orElse(Member.from(userResource));
 

--- a/src/main/java/com/flytrap/venusplanner/api/auth_member/presentation/controller/AuthMemberController.java
+++ b/src/main/java/com/flytrap/venusplanner/api/auth_member/presentation/controller/AuthMemberController.java
@@ -1,9 +1,10 @@
 package com.flytrap.venusplanner.api.auth_member.presentation.controller;
 
 import com.flytrap.venusplanner.api.auth_member.business.service.AuthMemberService;
+import com.flytrap.venusplanner.api.member.domain.Member;
 import com.flytrap.venusplanner.api.auth_member.presentation.dto.LoginDto;
 import com.flytrap.venusplanner.api.auth_member.presentation.dto.SessionMember;
-import com.flytrap.venusplanner.api.member.domain.Member;
+import com.flytrap.venusplanner.global.auth.infrastructure.properties.AuthSessionProperties;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AuthMemberController {
 
+    private final AuthSessionProperties authSessionProperties;
     private final AuthMemberService authMemberService;
 
     @PostMapping("/auth/sign-in")
@@ -25,7 +27,7 @@ public class AuthMemberController {
             HttpSession session
     ) {
         Member member = authMemberService.authenticateAndFetchMember(request);
-        session.setAttribute("SESSION_NAME", SessionMember.from(member));
+        session.setAttribute(authSessionProperties.sessionName(), SessionMember.from(member));
 
         return ResponseEntity.ok().body(LoginDto.Response.from(member));
     }

--- a/src/main/java/com/flytrap/venusplanner/global/auth/config/OAuthPropertiesConfig.java
+++ b/src/main/java/com/flytrap/venusplanner/global/auth/config/OAuthPropertiesConfig.java
@@ -1,0 +1,11 @@
+package com.flytrap.venusplanner.global.auth.config;
+
+import com.flytrap.venusplanner.global.auth.infrastructure.properties.GitHubOAuthProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties({GitHubOAuthProperties.class})
+public class OAuthPropertiesConfig {
+
+}

--- a/src/main/java/com/flytrap/venusplanner/global/auth/config/OAuthWebClientConfig.java
+++ b/src/main/java/com/flytrap/venusplanner/global/auth/config/OAuthWebClientConfig.java
@@ -1,0 +1,44 @@
+package com.flytrap.venusplanner.global.auth.config;
+
+import com.flytrap.venusplanner.global.auth.infrastructure.properties.GitHubOAuthProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+@RequiredArgsConstructor
+public class OAuthWebClientConfig {
+
+    private final GitHubOAuthProperties gitHubOAuthProperties;
+
+    @Component
+    public class GitHubOAuthFormDataBuilder {
+        public MultiValueMap<String, String> buildFormData(String code) {
+            MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+            formData.add("code", code);
+            formData.add("client_id", gitHubOAuthProperties.clientId());
+            formData.add("client_secret", gitHubOAuthProperties.clientSecret());
+
+            return formData;
+        }
+    }
+
+    @Bean(name = "gitHubAccessTokenClient")
+    public WebClient gitHubAccessTokenClient() {
+        return WebClient.builder().baseUrl(gitHubOAuthProperties.accessTokenUri()).build();
+    }
+
+    @Bean(name = "gitHubUserResourceClient")
+    public WebClient gitHubUserResourceClient() {
+        return WebClient.builder().baseUrl(gitHubOAuthProperties.userResourceUri()).build();
+    }
+
+    @Bean(name = "gitHubEmailResourceClient")
+    public WebClient gitHubEmailResourceClient() {
+        return WebClient.builder().baseUrl(gitHubOAuthProperties.userEmailResourceUri()).build();
+    }
+}

--- a/src/main/java/com/flytrap/venusplanner/global/auth/exception/GitHubOAuthRequestException.java
+++ b/src/main/java/com/flytrap/venusplanner/global/auth/exception/GitHubOAuthRequestException.java
@@ -1,0 +1,7 @@
+package com.flytrap.venusplanner.global.auth.exception;
+
+public class GitHubOAuthRequestException extends RuntimeException {
+    public GitHubOAuthRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/flytrap/venusplanner/global/auth/infrastructure/api/GitHubOAuthProvider.java
+++ b/src/main/java/com/flytrap/venusplanner/global/auth/infrastructure/api/GitHubOAuthProvider.java
@@ -1,0 +1,156 @@
+package com.flytrap.venusplanner.global.auth.infrastructure.api;
+
+import com.flytrap.venusplanner.global.auth.config.OAuthWebClientConfig.GitHubOAuthFormDataBuilder;
+import com.flytrap.venusplanner.global.auth.exception.GitHubOAuthRequestException;
+import com.flytrap.venusplanner.global.auth.infrastructure.dto.AccessTokenFromGitHub;
+import com.flytrap.venusplanner.global.auth.infrastructure.dto.StandardizedUserResource;
+import com.flytrap.venusplanner.global.auth.infrastructure.dto.UserEmailResourceFromGitHub;
+import com.flytrap.venusplanner.global.auth.infrastructure.dto.UserResourceFromGitHub;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class GitHubOAuthProvider implements OAuthProvider {
+
+    private final GitHubOAuthFormDataBuilder gitHubOAuthFormDataBuilder;
+    private final WebClient gitHubAccessTokenClient;
+    private final WebClient gitHubUserResourceClient;
+    private final WebClient gitHubEmailResourceClient;
+
+    /**
+     * GitHub OAuth에서 회원 인증 후 회원 정보를 반환합니다.
+     * <p>
+     * @param code GitHub OAuth 인증 과정에서 얻은 인증 코드
+     * @return 사용자 정보를 담고 있는 {@link StandardizedUserResource} 객체입니다.
+     * @throws GitHubOAuthRequestException GitHub 요청 과정에서 오류가 발생했을 때 발생합니다.
+     * 이는 네트워크 문제, 데이터 포맷 문제, 서버 측 오류 등 다양한 이유로 발생할 수 있습니다.
+     */
+    public StandardizedUserResource authenticateAndFetchMember(String code) {
+
+        var accessToken = requestAccessToken(code);
+        var userResource = requestUserResource(accessToken);
+
+        return StandardizedUserResource.from(userResource);
+    }
+
+    /**
+     * GitHub OAuth 서버로부터 액세스 토큰을 요청합니다.
+     * <p>
+     * 이 메서드는 매개변수로 주어진 인증 코드를 사용하여 GitHub OAuth 서버에 액세스 토큰을 요청합니다. 요청이 성공하면, 액세스 토큰이 담긴
+     * {@link AccessTokenFromGitHub} 객체를 반환합니다. 요청 중 발생하는 모든 4xx 및 5xx HTTP 응답 코드는
+     * {@link GitHubOAuthRequestException}을 발생시킵니다.
+     * <p>
+     * @param code GitHub OAuth 인증 과정에서 얻은 인증 코드
+     * @return 액세스 토큰 정보를 담고 있는 {@link AccessTokenFromGitHub}
+     * @throws GitHubOAuthRequestException GitHub OAuth 요청 과정에서 발생하는 모든 예외를 포함합니다.
+     * 이는 네트워크 문제, 데이터 포맷 문제, 서버 측 오류 등을 포함할 수 있습니다.
+     */
+    private AccessTokenFromGitHub requestAccessToken(String code) {
+
+        MultiValueMap<String, String> formData = gitHubOAuthFormDataBuilder.buildFormData(code);
+
+        // TODO: GlobalExceptionHandler 에서 GitHubOAuthRequestException 처리하기
+        return gitHubAccessTokenClient
+                .post()
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters.fromFormData(formData))
+                .retrieve()
+                .onStatus(
+                        statusCode -> statusCode.is4xxClientError() || statusCode.is5xxServerError(),
+                        response -> response.bodyToMono(String.class)
+                                        .flatMap(body -> Mono.error(new GitHubOAuthRequestException(body))))
+                .bodyToMono(AccessTokenFromGitHub.class)
+                .doOnError(error -> log.error("GitHub에서 액세스 토큰을 요청하는 중 에러 발생", error))
+                .onErrorMap(throwable -> new GitHubOAuthRequestException(throwable.getMessage()))
+                .block();
+    }
+
+    /**
+     * GitHub에서 사용자 정보를 요청합니다.
+     * <p>
+     * 이 메서드는 주어진 액세스 토큰을 사용하여 GitHub의 사용자 정보 리소스에 대한 GET 요청을 실행합니다. 요청이 성공하면,
+     * {@link UserResourceFromGitHub} 객체를 반환합니다. 요청 중에 4xx 또는 5xx HTTP 상태 코드가 반환되는 경우,
+     * {@link GitHubOAuthRequestException}을 발생시킵니다.
+     * <p>
+     *
+     * @param accessToken GitHub OAuth를 통해 얻은 액세스 토큰, {@link AccessTokenFromGitHub} 객체입니다.
+     * @return 사용자 정보를 담고 있는 {@link UserResourceFromGitHub} 객체입니다. 사용자 정보에 이메일이 포함됩니다.
+     * @throws GitHubOAuthRequestException GitHub 요청 과정에서 오류가 발생했을 때 발생합니다.
+     * 이는 네트워크 문제, 데이터 포맷 문제, 서버 측 오류 등 다양한 이유로 발생할 수 있습니다.
+     */
+    private UserResourceFromGitHub requestUserResource(AccessTokenFromGitHub accessToken) {
+
+        return gitHubUserResourceClient
+                .get()
+                .header(HttpHeaders.AUTHORIZATION, accessToken.getHeadValue())
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .onStatus(
+                        statusCode -> statusCode.is4xxClientError() || statusCode.is5xxServerError(),
+                        response -> response.bodyToMono(String.class)
+                                .flatMap(body -> Mono.error(new GitHubOAuthRequestException(body))))
+                .bodyToMono(UserResourceFromGitHub.class)
+                .flatMap(userResource -> {
+                    if (userResource.isEmailEmpty()) {
+                        return requestPrimaryUserEmailResource(accessToken)
+                                .map(email -> {
+                                    userResource.updateEmail(email);
+
+                                    return userResource;
+                                });
+                    }
+
+                    return Mono.just(userResource);
+                })
+                .doOnError(error -> log.error("GitHub에서 회원 정보를 요청하는 중 에러 발생", error))
+                .onErrorMap(throwable -> new GitHubOAuthRequestException(throwable.getMessage()))
+                .block();
+    }
+
+    /**
+     * GitHub에서 사용자의 이메일 정보를 요청합니다.
+     * <p>
+     * 이 메서드는 주어진 액세스 토큰을 사용하여 GitHub의 사용자 이메일 정보 리소스에 대한 GET 요청을 실행합니다.
+     * 요청이 성공하면, 이메일 정보 목록 중 첫 번째 이메일 주소를 문자열로 반환합니다. 만약 이메일 정보 목록이 비어 있으면,
+     * 빈 문자열을 반환합니다. 요청 중에 4xx 또는 5xx HTTP 상태 코드가 반환되는 경우,
+     * {@link GitHubOAuthRequestException}을 Mono.error()로 반환합니다.
+     * <p>
+     * GitHub에서 사용자 정보를 요청할 때 email은 비공개 설정일 경우 반환하지 않기 때문에 이 메서드로 email을 추가 요청해야 합니다.
+     * <p>
+     * @param accessToken GitHub OAuth를 통해 얻은 액세스 토큰, {@link AccessTokenFromGitHub} 객체입니다.
+     * @return 사용자의 첫 번째 이메일 주소를 담고 있는 문자열의 Mono입니다. 이메일 목록이 비어 있을 경우 빈 문자열을 반환합니다.
+     * @throws GitHubOAuthRequestException GitHub 요청 과정에서 오류가 발생했을 때 발생합니다.
+     * 이는 네트워크 문제, 데이터 포맷 문제, 서버 측 오류 등 다양한 이유로 발생할 수 있습니다.
+     * <p>
+     */
+    private Mono<String> requestPrimaryUserEmailResource(AccessTokenFromGitHub accessToken) {
+
+        return gitHubEmailResourceClient
+                .get()
+                .header(HttpHeaders.ACCEPT, "application/vnd.github+json")
+                .header(HttpHeaders.AUTHORIZATION, accessToken.getHeadValue())
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .onStatus(
+                        statusCode -> statusCode.is4xxClientError() || statusCode.is5xxServerError(),
+                        response -> response.bodyToMono(String.class)
+                                .flatMap(body -> Mono.error(new GitHubOAuthRequestException(body))))
+                .bodyToMono(new ParameterizedTypeReference<List<UserEmailResourceFromGitHub>>() {})
+                .map(emailList -> emailList.isEmpty() ? "" : emailList.get(0).email())
+                .doOnError(error -> log.error("GitHub에서 이메일 정보를 요청하는 중 에러 발생", error))
+                .onErrorMap(throwable -> new GitHubOAuthRequestException(throwable.getMessage()));
+    }
+
+}

--- a/src/main/java/com/flytrap/venusplanner/global/auth/infrastructure/api/GitHubOAuthProvider.java
+++ b/src/main/java/com/flytrap/venusplanner/global/auth/infrastructure/api/GitHubOAuthProvider.java
@@ -36,7 +36,7 @@ public class GitHubOAuthProvider implements OAuthProvider {
      * @throws GitHubOAuthRequestException GitHub 요청 과정에서 오류가 발생했을 때 발생합니다.
      * 이는 네트워크 문제, 데이터 포맷 문제, 서버 측 오류 등 다양한 이유로 발생할 수 있습니다.
      */
-    public StandardizedUserResource authenticateAndFetchMember(String code) {
+    public StandardizedUserResource authenticateAndFetchUserResource(String code) {
 
         var accessToken = requestAccessToken(code);
         var userResource = requestUserResource(accessToken);

--- a/src/main/java/com/flytrap/venusplanner/global/auth/infrastructure/dto/AccessTokenFromGitHub.java
+++ b/src/main/java/com/flytrap/venusplanner/global/auth/infrastructure/dto/AccessTokenFromGitHub.java
@@ -1,0 +1,12 @@
+package com.flytrap.venusplanner.global.auth.infrastructure.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record AccessTokenFromGitHub(
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("token_type") String tokenType
+) {
+    public String getHeadValue() {
+        return String.format("%s %s", tokenType, accessToken);
+    }
+}

--- a/src/main/java/com/flytrap/venusplanner/global/auth/infrastructure/dto/StandardizedUserResource.java
+++ b/src/main/java/com/flytrap/venusplanner/global/auth/infrastructure/dto/StandardizedUserResource.java
@@ -9,5 +9,13 @@ public record StandardizedUserResource(
         String profileUrl,
         OAuthPlatformType authPlatformType
 ) {
-
+    public static StandardizedUserResource from(UserResourceFromGitHub userResource) {
+        return new StandardizedUserResource(
+                userResource.getOAuthPk(),
+                userResource.getEmail(),
+                userResource.getLogin(),
+                userResource.getAvatarUrl(),
+                OAuthPlatformType.GITHUB
+        );
+    }
 }

--- a/src/main/java/com/flytrap/venusplanner/global/auth/infrastructure/dto/UserEmailResourceFromGitHub.java
+++ b/src/main/java/com/flytrap/venusplanner/global/auth/infrastructure/dto/UserEmailResourceFromGitHub.java
@@ -1,0 +1,9 @@
+package com.flytrap.venusplanner.global.auth.infrastructure.dto;
+
+public record UserEmailResourceFromGitHub(
+        String email,
+        boolean verified,
+        boolean primary,
+        String visibility
+) {
+}

--- a/src/main/java/com/flytrap/venusplanner/global/auth/infrastructure/dto/UserResourceFromGitHub.java
+++ b/src/main/java/com/flytrap/venusplanner/global/auth/infrastructure/dto/UserResourceFromGitHub.java
@@ -1,0 +1,30 @@
+package com.flytrap.venusplanner.global.auth.infrastructure.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserResourceFromGitHub {
+
+    private Long id; // OAuthPk
+    private String email;
+    private String login;
+
+    @JsonProperty("avatar_url")
+    private String avatarUrl;
+
+    public String getOAuthPk() {
+        return String.valueOf(id);
+    }
+
+    public boolean isEmailEmpty() {
+        return email == null || email.isEmpty();
+    }
+
+    public void updateEmail(String email) {
+        this.email = email;
+    }
+
+}

--- a/src/main/java/com/flytrap/venusplanner/global/auth/infrastructure/properties/AuthSessionProperties.java
+++ b/src/main/java/com/flytrap/venusplanner/global/auth/infrastructure/properties/AuthSessionProperties.java
@@ -1,0 +1,9 @@
+package com.flytrap.venusplanner.global.auth.infrastructure.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "auth.session")
+public record AuthSessionProperties(
+        String sessionName
+) {
+}

--- a/src/main/java/com/flytrap/venusplanner/global/auth/infrastructure/properties/GitHubOAuthProperties.java
+++ b/src/main/java/com/flytrap/venusplanner/global/auth/infrastructure/properties/GitHubOAuthProperties.java
@@ -1,0 +1,14 @@
+package com.flytrap.venusplanner.global.auth.infrastructure.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "oauth.github")
+public record GitHubOAuthProperties(
+        String clientId,
+        String clientSecret,
+        String userResourceUri,
+        String userEmailResourceUri,
+        String accessTokenUri,
+        String redirectUri
+) {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   profiles:
     active: local
     group:
-      local: [ local ] # localhost
+      local: [ local, oauth-local ] # localhost
       prod: [ prod ] # aws ec2
     include: [ auth ]
   jpa:


### PR DESCRIPTION
# ✨ Key changes
- [ ] #2 
  

# 👋 To reviewers
## 구현 내용
- GitHub OAuth 서버에서 회원을 인증하고 회원 정보를 가져오는 외부 API를 호출하는 로직입니다.

### 참고 문서
[Authorizing OAuth apps](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps)
[Get the authenticated user](https://docs.github.com/en/rest/users/users?apiVersion=2022-11-28#get-the-authenticated-user)
[List email addresses for the authenticated user](https://docs.github.com/en/rest/users/emails?apiVersion=2022-11-28#list-email-addresses-for-the-authenticated-user)

## 현재 구조
![Planner OAuth 구조 drawio1](https://github.com/FlytrapHub/venus-planner-be/assets/86359180/20893f0d-b529-4f8c-8ff4-5817c3658699)

## 다른 OAuth 플랫폼 추가시 변경될 구조
![Planner OAuth 구조 drawio2](https://github.com/FlytrapHub/venus-planner-be/assets/86359180/635e1eb8-aa05-400f-9d35-49593150105a)

- OAuth 플랫폼 별 OAuthProvider Bean들을 List로 자동 주입하여 인증을 요청한 플랫폼에 맞는 OAuthProvider를 실행하는 구조