### PR TITLE
[feat] 로그인 상태를 검증해 주는 ArgumentResolver 구현

### DIFF
--- a/src/main/java/com/flytrap/venusplanner/api/auth_member/business/service/AuthMemberService.java
+++ b/src/main/java/com/flytrap/venusplanner/api/auth_member/business/service/AuthMemberService.java
@@ -20,7 +20,6 @@ public class AuthMemberService {
     public Member authenticateAndFetchMember(LoginDto.Request request) {
 
         var userResource = oAuthProvider.authenticateAndFetchUserResource(request.code());
-
         var authenticatedMember = memberRepository.findByOauthPk(userResource.oauthPk())
                 .orElse(Member.from(userResource));
 

--- a/src/main/java/com/flytrap/venusplanner/api/auth_member/presentation/controller/AuthMemberController.java
+++ b/src/main/java/com/flytrap/venusplanner/api/auth_member/presentation/controller/AuthMemberController.java
@@ -8,6 +8,7 @@ import com.flytrap.venusplanner.global.auth.infrastructure.properties.AuthSessio
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,5 +31,13 @@ public class AuthMemberController {
         session.setAttribute(authSessionProperties.sessionName(), SessionMember.from(member));
 
         return ResponseEntity.ok().body(LoginDto.Response.from(member));
+    }
+
+    @DeleteMapping("/auth/sign-out")
+    public ResponseEntity<Void> signOut(HttpSession session) {
+
+        session.invalidate();
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/flytrap/venusplanner/api/auth_member/presentation/controller/AuthMemberController.java
+++ b/src/main/java/com/flytrap/venusplanner/api/auth_member/presentation/controller/AuthMemberController.java
@@ -3,7 +3,7 @@ package com.flytrap.venusplanner.api.auth_member.presentation.controller;
 import com.flytrap.venusplanner.api.auth_member.business.service.AuthMemberService;
 import com.flytrap.venusplanner.api.member.domain.Member;
 import com.flytrap.venusplanner.api.auth_member.presentation.dto.LoginDto;
-import com.flytrap.venusplanner.api.auth_member.presentation.dto.SessionMember;
+import com.flytrap.venusplanner.global.auth.dto.SessionMember;
 import com.flytrap.venusplanner.global.auth.infrastructure.properties.AuthSessionProperties;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/flytrap/venusplanner/global/auth/annotation/SignIn.java
+++ b/src/main/java/com/flytrap/venusplanner/global/auth/annotation/SignIn.java
@@ -1,0 +1,12 @@
+package com.flytrap.venusplanner.global.auth.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SignIn {
+
+}

--- a/src/main/java/com/flytrap/venusplanner/global/auth/config/SignInArgumentResolverConfig.java
+++ b/src/main/java/com/flytrap/venusplanner/global/auth/config/SignInArgumentResolverConfig.java
@@ -1,0 +1,21 @@
+package com.flytrap.venusplanner.global.auth.config;
+
+import com.flytrap.venusplanner.global.auth.resolver.SignInArgumentResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class SignInArgumentResolverConfig implements WebMvcConfigurer {
+
+    private final SignInArgumentResolver signInArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(signInArgumentResolver);
+    }
+
+}

--- a/src/main/java/com/flytrap/venusplanner/global/auth/dto/SessionMember.java
+++ b/src/main/java/com/flytrap/venusplanner/global/auth/dto/SessionMember.java
@@ -1,4 +1,4 @@
-package com.flytrap.venusplanner.api.auth_member.presentation.dto;
+package com.flytrap.venusplanner.global.auth.dto;
 
 import com.flytrap.venusplanner.api.member.domain.Member;
 import java.io.Serializable;

--- a/src/main/java/com/flytrap/venusplanner/global/auth/exception/SessionMemberAuthException.java
+++ b/src/main/java/com/flytrap/venusplanner/global/auth/exception/SessionMemberAuthException.java
@@ -1,0 +1,7 @@
+package com.flytrap.venusplanner.global.auth.exception;
+
+public class SessionMemberAuthException extends RuntimeException {
+    public SessionMemberAuthException() {
+        super("로그인이 필요한 기능입니다.");
+    }
+}

--- a/src/main/java/com/flytrap/venusplanner/global/auth/resolver/SignInArgumentResolver.java
+++ b/src/main/java/com/flytrap/venusplanner/global/auth/resolver/SignInArgumentResolver.java
@@ -1,6 +1,6 @@
 package com.flytrap.venusplanner.global.auth.resolver;
 
-import com.flytrap.venusplanner.api.auth_member.presentation.dto.SessionMember;
+import com.flytrap.venusplanner.global.auth.dto.SessionMember;
 import com.flytrap.venusplanner.global.auth.annotation.SignIn;
 import com.flytrap.venusplanner.global.auth.exception.SessionMemberAuthException;
 import com.flytrap.venusplanner.global.auth.infrastructure.properties.AuthSessionProperties;

--- a/src/main/java/com/flytrap/venusplanner/global/auth/resolver/SignInArgumentResolver.java
+++ b/src/main/java/com/flytrap/venusplanner/global/auth/resolver/SignInArgumentResolver.java
@@ -1,0 +1,52 @@
+package com.flytrap.venusplanner.global.auth.resolver;
+
+import com.flytrap.venusplanner.api.auth_member.presentation.dto.SessionMember;
+import com.flytrap.venusplanner.global.auth.annotation.SignIn;
+import com.flytrap.venusplanner.global.auth.exception.SessionMemberAuthException;
+import com.flytrap.venusplanner.global.auth.infrastructure.properties.AuthSessionProperties;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class SignInArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final AuthSessionProperties authSessionProperties;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+
+        boolean hasSignInAnnotation = parameter.hasParameterAnnotation(SignIn.class);
+        boolean hasSessionMemberType = SessionMember.class.isAssignableFrom(parameter.getParameterType());
+
+        return hasSignInAnnotation && hasSessionMemberType;
+    }
+
+    @Override
+    public SessionMember resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+
+        return extractSessionMember(request)
+                .orElseThrow(SessionMemberAuthException::new);
+    }
+
+    private Optional<SessionMember> extractSessionMember(HttpServletRequest request) {
+
+        HttpSession session = request.getSession(false);
+
+        return Optional.ofNullable(session)
+                .map(s -> s.getAttribute(authSessionProperties.sessionName()))
+                .filter(SessionMember.class::isInstance)
+                .map(SessionMember.class::cast);
+    }
+}


### PR DESCRIPTION
# ✨ Key changes
- [ ] #2 
  

# 👋 To reviewers
## SignInArgumentResolver 사용법
- 다음과 같이 Controller 매개 변수에 `@SignIn SessionMember sessionMmeber`를 추가합니다.
- `SessionMember`는 Member의 id를 포함하고 있습니다. 이 id를 사용해서 특정 회원과 관련된 작업을 수행할 수 있습니다.
```java
public ResponseEntity<Void> doSomething(@SignIn SessionMember sessionMmeber) {

    log.debug("Member id = {}", sessionMember.id());

    return ResponseEntity.ok();
}
```
- 매개변수에 `@SignIn SessionMember sessionMmeber`가 있으면 SignInArgumentResolver가 Session Store에서 현재 로그인된 회원의 정보(Member의 id)가 담긴 SessionMember를 자동으로 할당해 줍니다.
- 로그인 상태가 아니면 `SessionMemberAuthException`을 발생시킵니다. 
- `TODO`: 추 후 GlobalExceptionHandler가 구현되면 `SessionMemberAuthException` 발생시 401 상태 코드를 반환하도록 해야 합니다. (#16) 