### PR TITLE
[feat] `Plan` 생성 기본 기능 구현 

### DIFF
--- a/src/main/java/com/flytrap/venusplanner/api/plan/business/service/PlanService.java
+++ b/src/main/java/com/flytrap/venusplanner/api/plan/business/service/PlanService.java
@@ -1,7 +1,6 @@
 package com.flytrap.venusplanner.api.plan.business.service;
 
 import com.flytrap.venusplanner.api.plan.domain.Plan;
-import com.flytrap.venusplanner.api.plan.domain.RecurringOption;
 import com.flytrap.venusplanner.api.plan.infrastructure.repository.PlanRepository;
 import com.flytrap.venusplanner.api.plan_category.domain.PlanCategory;
 import com.flytrap.venusplanner.api.study.domain.Study;
@@ -18,9 +17,8 @@ public class PlanService {
     private final PlanRepository planRepository;
 
     public Long savePlan(Study study, PlanCategory planCategory, StudyPlanCreateRequest request) {
-        // TODO 반복 옵션 만들기
-        RecurringOption recurringOption = null;
-        Plan plan = request.toEntity(study, planCategory, recurringOption);
+        //TODO: 반복 옵션 설정시 DB에 여러 plan 저장 로직 추가
+        Plan plan = request.toEntity(study, planCategory);
         planRepository.save(plan);
 
         return plan.getId();

--- a/src/main/java/com/flytrap/venusplanner/api/plan/business/service/PlanService.java
+++ b/src/main/java/com/flytrap/venusplanner/api/plan/business/service/PlanService.java
@@ -1,0 +1,28 @@
+package com.flytrap.venusplanner.api.plan.business.service;
+
+import com.flytrap.venusplanner.api.plan.domain.Plan;
+import com.flytrap.venusplanner.api.plan.domain.RecurringOption;
+import com.flytrap.venusplanner.api.plan.infrastructure.repository.PlanRepository;
+import com.flytrap.venusplanner.api.plan_category.domain.PlanCategory;
+import com.flytrap.venusplanner.api.study.domain.Study;
+import com.flytrap.venusplanner.api.study_plan.presentation.dto.request.StudyPlanCreateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PlanService {
+
+    private final PlanRepository planRepository;
+
+    public Long savePlan(Study study, PlanCategory planCategory, StudyPlanCreateRequest request) {
+        // TODO 반복 옵션 만들기
+        RecurringOption recurringOption = null;
+        Plan plan = request.toEntity(study, planCategory, recurringOption);
+        planRepository.save(plan);
+
+        return plan.getId();
+    }
+}

--- a/src/main/java/com/flytrap/venusplanner/api/plan/domain/EndOption.java
+++ b/src/main/java/com/flytrap/venusplanner/api/plan/domain/EndOption.java
@@ -1,0 +1,5 @@
+package com.flytrap.venusplanner.api.plan.domain;
+
+public enum EndOption {
+    DATE, COUNT;
+}

--- a/src/main/java/com/flytrap/venusplanner/api/plan/domain/EndOption.java
+++ b/src/main/java/com/flytrap/venusplanner/api/plan/domain/EndOption.java
@@ -1,5 +1,5 @@
 package com.flytrap.venusplanner.api.plan.domain;
 
 public enum EndOption {
-    DATE, COUNT;
+    DATE, COUNT
 }

--- a/src/main/java/com/flytrap/venusplanner/api/plan/domain/Frequency.java
+++ b/src/main/java/com/flytrap/venusplanner/api/plan/domain/Frequency.java
@@ -1,5 +1,5 @@
 package com.flytrap.venusplanner.api.plan.domain;
 
 public enum Frequency {
-    WEEKLY, MONTHLY, YEARLY;
+    WEEKLY, MONTHLY, YEARLY
 }

--- a/src/main/java/com/flytrap/venusplanner/api/plan/domain/Frequency.java
+++ b/src/main/java/com/flytrap/venusplanner/api/plan/domain/Frequency.java
@@ -1,0 +1,5 @@
+package com.flytrap.venusplanner.api.plan.domain;
+
+public enum Frequency {
+    WEEKLY, MONTHLY, YEARLY;
+}

--- a/src/main/java/com/flytrap/venusplanner/api/plan/domain/Plan.java
+++ b/src/main/java/com/flytrap/venusplanner/api/plan/domain/Plan.java
@@ -1,0 +1,49 @@
+package com.flytrap.venusplanner.api.plan.domain;
+
+import com.flytrap.venusplanner.api.study.domain.PlanCategory;
+import com.flytrap.venusplanner.api.study.domain.Study;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Plan {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_id", nullable = false)
+    private Study study;
+
+    @ManyToOne
+    @JoinColumn(name = "plan_category_id")
+    private PlanCategory planCategory;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recurring_option_id")
+    private RecurringOption recurringOption;
+
+    private String title; // Null 이면 default: 새로운 일정
+    private String description;
+
+    @NotNull
+    private Instant start_time;
+
+    @NotNull
+    private Instant end_time;
+
+    private Instant notification_time;
+}

--- a/src/main/java/com/flytrap/venusplanner/api/plan/domain/Plan.java
+++ b/src/main/java/com/flytrap/venusplanner/api/plan/domain/Plan.java
@@ -9,12 +9,16 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.CascadeType;
 
 @Entity
 @Getter
@@ -35,9 +39,10 @@ public class Plan {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "recurring_option_id")
+    @Cascade(CascadeType.ALL)
     private RecurringOption recurringOption;
 
-    private String title; // Null 이면 default: 새로운 일정
+    private String title;
     private String description;
 
     @NotNull
@@ -60,5 +65,15 @@ public class Plan {
         this.startTime = startTime;
         this.endTime = endTime;
         this.notificationTime = notificationTime;
+    }
+
+    @PrePersist
+    @PreUpdate
+    public void validateTitle() {
+        final String DEFAULT_TILE = "새로운 일정";
+
+        if (title == null || title.isBlank()) {
+            title = DEFAULT_TILE;
+        }
     }
 }

--- a/src/main/java/com/flytrap/venusplanner/api/plan/domain/Plan.java
+++ b/src/main/java/com/flytrap/venusplanner/api/plan/domain/Plan.java
@@ -1,6 +1,6 @@
 package com.flytrap.venusplanner.api.plan.domain;
 
-import com.flytrap.venusplanner.api.study.domain.PlanCategory;
+import com.flytrap.venusplanner.api.plan_category.domain.PlanCategory;
 import com.flytrap.venusplanner.api.study.domain.Study;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -12,6 +12,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -40,10 +41,24 @@ public class Plan {
     private String description;
 
     @NotNull
-    private Instant start_time;
+    private Instant startTime;
 
     @NotNull
-    private Instant end_time;
+    private Instant endTime;
 
-    private Instant notification_time;
+    private Instant notificationTime;
+
+    @Builder
+    private Plan(Study study, PlanCategory planCategory, RecurringOption recurringOption, String title,
+                 String description,
+                 Instant startTime, Instant endTime, Instant notificationTime) {
+        this.study = study;
+        this.planCategory = planCategory;
+        this.recurringOption = recurringOption;
+        this.title = title;
+        this.description = description;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.notificationTime = notificationTime;
+    }
 }

--- a/src/main/java/com/flytrap/venusplanner/api/plan/domain/RecurringOption.java
+++ b/src/main/java/com/flytrap/venusplanner/api/plan/domain/RecurringOption.java
@@ -6,9 +6,9 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,16 +22,19 @@ public class RecurringOption {
     private Long id;
 
     @Enumerated(EnumType.STRING)
-    @NotNull
     private Frequency frequency;
 
     @Enumerated(EnumType.STRING)
-    @NotNull
-    private EndOption end_option;
+    private EndOption endOption;
+    private Integer recurrenceCount;
+    private Instant endDate;
 
-    @NotNull
-    private Integer recurrence_count;
-
-    @NotNull
-    private Instant end_date;
+    @Builder
+    public RecurringOption(Frequency frequency, EndOption endOption,
+                           Integer recurrenceCount, Instant endDate) {
+        this.frequency = frequency;
+        this.endOption = endOption;
+        this.recurrenceCount = recurrenceCount;
+        this.endDate = endDate;
+    }
 }

--- a/src/main/java/com/flytrap/venusplanner/api/plan/domain/RecurringOption.java
+++ b/src/main/java/com/flytrap/venusplanner/api/plan/domain/RecurringOption.java
@@ -1,0 +1,37 @@
+package com.flytrap.venusplanner.api.plan.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecurringOption {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    private Frequency frequency;
+
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    private EndOption end_option;
+
+    @NotNull
+    private Integer recurrence_count;
+
+    @NotNull
+    private Instant end_date;
+}

--- a/src/main/java/com/flytrap/venusplanner/api/plan/infrastructure/repository/PlanRepository.java
+++ b/src/main/java/com/flytrap/venusplanner/api/plan/infrastructure/repository/PlanRepository.java
@@ -1,0 +1,9 @@
+package com.flytrap.venusplanner.api.plan.infrastructure.repository;
+
+import com.flytrap.venusplanner.api.plan.domain.Plan;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PlanRepository extends JpaRepository<Plan, Long> {
+}

--- a/src/main/java/com/flytrap/venusplanner/api/plan/infrastructure/repository/RecurringOptionRepository.java
+++ b/src/main/java/com/flytrap/venusplanner/api/plan/infrastructure/repository/RecurringOptionRepository.java
@@ -1,0 +1,9 @@
+package com.flytrap.venusplanner.api.plan.infrastructure.repository;
+
+import com.flytrap.venusplanner.api.plan.domain.RecurringOption;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RecurringOptionRepository extends JpaRepository<RecurringOption, Long> {
+}

--- a/src/main/java/com/flytrap/venusplanner/api/plan_category/business/service/PlanCategoryService.java
+++ b/src/main/java/com/flytrap/venusplanner/api/plan_category/business/service/PlanCategoryService.java
@@ -1,0 +1,20 @@
+package com.flytrap.venusplanner.api.plan_category.business.service;
+
+import com.flytrap.venusplanner.api.plan_category.domain.PlanCategory;
+import com.flytrap.venusplanner.api.plan_category.infrastructure.repository.PlanCategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PlanCategoryService {
+
+    private final PlanCategoryRepository planCategoryRepository;
+
+    public PlanCategory findById(Long id) {
+        //TODO: optional null일 때 에러처리
+        return planCategoryRepository.findById(id).get();
+    }
+}

--- a/src/main/java/com/flytrap/venusplanner/api/plan_category/domain/PlanCategory.java
+++ b/src/main/java/com/flytrap/venusplanner/api/plan_category/domain/PlanCategory.java
@@ -1,5 +1,6 @@
-package com.flytrap.venusplanner.api.study.domain;
+package com.flytrap.venusplanner.api.plan_category.domain;
 
+import com.flytrap.venusplanner.api.study.domain.Study;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;

--- a/src/main/java/com/flytrap/venusplanner/api/plan_category/infrastructure/repository/PlanCategoryRepository.java
+++ b/src/main/java/com/flytrap/venusplanner/api/plan_category/infrastructure/repository/PlanCategoryRepository.java
@@ -1,0 +1,9 @@
+package com.flytrap.venusplanner.api.plan_category.infrastructure.repository;
+
+import com.flytrap.venusplanner.api.plan_category.domain.PlanCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PlanCategoryRepository extends JpaRepository<PlanCategory, Long> {
+}

--- a/src/main/java/com/flytrap/venusplanner/api/study/business/service/StudyService.java
+++ b/src/main/java/com/flytrap/venusplanner/api/study/business/service/StudyService.java
@@ -1,0 +1,20 @@
+package com.flytrap.venusplanner.api.study.business.service;
+
+import com.flytrap.venusplanner.api.study.domain.Study;
+import com.flytrap.venusplanner.api.study.infrastructure.repository.StudyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StudyService {
+
+    private final StudyRepository studyRepository;
+
+    public Study findById(Long studyId) {
+        //TODO: optional null 처리
+        return studyRepository.findById(studyId).get();
+    }
+}

--- a/src/main/java/com/flytrap/venusplanner/api/study/domain/PlanCategory.java
+++ b/src/main/java/com/flytrap/venusplanner/api/study/domain/PlanCategory.java
@@ -1,0 +1,36 @@
+package com.flytrap.venusplanner.api.study.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PlanCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_id", nullable = false)
+    private Study study;
+
+    @NotNull
+    private String title;
+
+    @NotNull
+    private String fontColor;
+
+    @NotNull
+    private String backgroundColor;
+}

--- a/src/main/java/com/flytrap/venusplanner/api/study/domain/Study.java
+++ b/src/main/java/com/flytrap/venusplanner/api/study/domain/Study.java
@@ -1,0 +1,26 @@
+package com.flytrap.venusplanner.api.study.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Study {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private String name;
+    private String description;
+    private Instant createdTime;
+}

--- a/src/main/java/com/flytrap/venusplanner/api/study/infrastructure/repository/StudyRepository.java
+++ b/src/main/java/com/flytrap/venusplanner/api/study/infrastructure/repository/StudyRepository.java
@@ -1,0 +1,9 @@
+package com.flytrap.venusplanner.api.study.infrastructure.repository;
+
+import com.flytrap.venusplanner.api.study.domain.Study;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StudyRepository extends JpaRepository<Study, Long> {
+}

--- a/src/main/java/com/flytrap/venusplanner/api/study_plan/business/service/StudyPlanFacadeService.java
+++ b/src/main/java/com/flytrap/venusplanner/api/study_plan/business/service/StudyPlanFacadeService.java
@@ -2,8 +2,8 @@ package com.flytrap.venusplanner.api.study_plan.business.service;
 
 import com.flytrap.venusplanner.api.plan.business.service.PlanService;
 import com.flytrap.venusplanner.api.plan_category.business.service.PlanCategoryService;
-import com.flytrap.venusplanner.api.study.business.service.StudyService;
 import com.flytrap.venusplanner.api.plan_category.domain.PlanCategory;
+import com.flytrap.venusplanner.api.study.business.service.StudyService;
 import com.flytrap.venusplanner.api.study.domain.Study;
 import com.flytrap.venusplanner.api.study_plan.presentation.dto.request.StudyPlanCreateRequest;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +19,7 @@ public class StudyPlanFacadeService {
     private final PlanCategoryService planCategoryService;
     private final PlanService planService;
 
+    @Transactional(readOnly = false)
     public Long savePlan(Long studyId, StudyPlanCreateRequest request) {
         Study study = studyService.findById(studyId);
         PlanCategory planCategory = planCategoryService.findById(request.categoryId());

--- a/src/main/java/com/flytrap/venusplanner/api/study_plan/business/service/StudyPlanFacadeService.java
+++ b/src/main/java/com/flytrap/venusplanner/api/study_plan/business/service/StudyPlanFacadeService.java
@@ -1,0 +1,27 @@
+package com.flytrap.venusplanner.api.study_plan.business.service;
+
+import com.flytrap.venusplanner.api.plan.business.service.PlanService;
+import com.flytrap.venusplanner.api.plan_category.business.service.PlanCategoryService;
+import com.flytrap.venusplanner.api.study.business.service.StudyService;
+import com.flytrap.venusplanner.api.plan_category.domain.PlanCategory;
+import com.flytrap.venusplanner.api.study.domain.Study;
+import com.flytrap.venusplanner.api.study_plan.presentation.dto.request.StudyPlanCreateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StudyPlanFacadeService {
+
+    private final StudyService studyService;
+    private final PlanCategoryService planCategoryService;
+    private final PlanService planService;
+
+    public Long savePlan(Long studyId, StudyPlanCreateRequest request) {
+        Study study = studyService.findById(studyId);
+        PlanCategory planCategory = planCategoryService.findById(request.categoryId());
+        return planService.savePlan(study, planCategory, request);
+    }
+}

--- a/src/main/java/com/flytrap/venusplanner/api/study_plan/presentation/controller/StudyPlanController.java
+++ b/src/main/java/com/flytrap/venusplanner/api/study_plan/presentation/controller/StudyPlanController.java
@@ -1,0 +1,27 @@
+package com.flytrap.venusplanner.api.study_plan.presentation.controller;
+
+import com.flytrap.venusplanner.api.study_plan.presentation.dto.request.StudyPlanCreateRequest;
+import com.flytrap.venusplanner.api.study_plan.business.service.StudyPlanFacadeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class StudyPlanController {
+
+    private final StudyPlanFacadeService studyPlanFacadeService;
+
+    @PostMapping("/api/v1/studies/{studyId}/plans")
+    public ResponseEntity<Long> createPlan(@PathVariable Long studyId, @RequestBody StudyPlanCreateRequest request) {
+        Long memberId = 1L;
+        Long planId = studyPlanFacadeService.savePlan(studyId, request);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(planId);
+    }
+}

--- a/src/main/java/com/flytrap/venusplanner/api/study_plan/presentation/controller/StudyPlanController.java
+++ b/src/main/java/com/flytrap/venusplanner/api/study_plan/presentation/controller/StudyPlanController.java
@@ -1,7 +1,8 @@
 package com.flytrap.venusplanner.api.study_plan.presentation.controller;
 
-import com.flytrap.venusplanner.api.study_plan.presentation.dto.request.StudyPlanCreateRequest;
 import com.flytrap.venusplanner.api.study_plan.business.service.StudyPlanFacadeService;
+import com.flytrap.venusplanner.api.study_plan.presentation.dto.request.StudyPlanCreateRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,7 +18,8 @@ public class StudyPlanController {
     private final StudyPlanFacadeService studyPlanFacadeService;
 
     @PostMapping("/api/v1/studies/{studyId}/plans")
-    public ResponseEntity<Long> createPlan(@PathVariable Long studyId, @RequestBody StudyPlanCreateRequest request) {
+    public ResponseEntity<Long> createPlan(@PathVariable("studyId") Long studyId,
+                                           @Valid @RequestBody StudyPlanCreateRequest request) {
         Long memberId = 1L;
         Long planId = studyPlanFacadeService.savePlan(studyId, request);
 

--- a/src/main/java/com/flytrap/venusplanner/api/study_plan/presentation/dto/request/RecurringOptionRequest.java
+++ b/src/main/java/com/flytrap/venusplanner/api/study_plan/presentation/dto/request/RecurringOptionRequest.java
@@ -2,6 +2,7 @@ package com.flytrap.venusplanner.api.study_plan.presentation.dto.request;
 
 import com.flytrap.venusplanner.api.plan.domain.EndOption;
 import com.flytrap.venusplanner.api.plan.domain.Frequency;
+import com.flytrap.venusplanner.api.plan.domain.RecurringOption;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 
@@ -11,7 +12,15 @@ public record RecurringOptionRequest(
 
         @NotNull
         EndOption endOption,
-        Integer count,
+        Integer recurrenceCount,
         Instant endDate
 ) {
+    public RecurringOption toEntity() {
+        return RecurringOption.builder()
+                .frequency(frequency)
+                .endOption(endOption)
+                .recurrenceCount(recurrenceCount)
+                .endDate(endDate)
+                .build();
+    }
 }

--- a/src/main/java/com/flytrap/venusplanner/api/study_plan/presentation/dto/request/RecurringOptionRequest.java
+++ b/src/main/java/com/flytrap/venusplanner/api/study_plan/presentation/dto/request/RecurringOptionRequest.java
@@ -1,0 +1,17 @@
+package com.flytrap.venusplanner.api.study_plan.presentation.dto.request;
+
+import com.flytrap.venusplanner.api.plan.domain.EndOption;
+import com.flytrap.venusplanner.api.plan.domain.Frequency;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+
+public record RecurringOptionRequest(
+        @NotNull
+        Frequency frequency,
+
+        @NotNull
+        EndOption endOption,
+        Integer count,
+        Instant endDate
+) {
+}

--- a/src/main/java/com/flytrap/venusplanner/api/study_plan/presentation/dto/request/StudyPlanCreateRequest.java
+++ b/src/main/java/com/flytrap/venusplanner/api/study_plan/presentation/dto/request/StudyPlanCreateRequest.java
@@ -4,15 +4,32 @@ import com.flytrap.venusplanner.api.plan.domain.Plan;
 import com.flytrap.venusplanner.api.plan.domain.RecurringOption;
 import com.flytrap.venusplanner.api.plan_category.domain.PlanCategory;
 import com.flytrap.venusplanner.api.study.domain.Study;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.time.Instant;
 
 public record StudyPlanCreateRequest(
+        @NotNull
         Long categoryId,
+
+        @NotBlank
+        @Size(min = 1, max = 100)
         String title,
+
+        @Size(max = 255)
         String description,
+
+        @NotNull
         Instant startTime,
+
+        @NotNull
         Instant endTime,
-        Instant notificationTime
+
+        @Future
+        Instant notificationTime,
+        RecurringOptionRequest recurringOption
 ) {
     public Plan toEntity(Study study, PlanCategory planCategory, RecurringOption recurringOption) {
         return Plan.builder()

--- a/src/main/java/com/flytrap/venusplanner/api/study_plan/presentation/dto/request/StudyPlanCreateRequest.java
+++ b/src/main/java/com/flytrap/venusplanner/api/study_plan/presentation/dto/request/StudyPlanCreateRequest.java
@@ -1,0 +1,29 @@
+package com.flytrap.venusplanner.api.study_plan.presentation.dto.request;
+
+import com.flytrap.venusplanner.api.plan.domain.Plan;
+import com.flytrap.venusplanner.api.plan.domain.RecurringOption;
+import com.flytrap.venusplanner.api.plan_category.domain.PlanCategory;
+import com.flytrap.venusplanner.api.study.domain.Study;
+import java.time.Instant;
+
+public record StudyPlanCreateRequest(
+        Long categoryId,
+        String title,
+        String description,
+        Instant startTime,
+        Instant endTime,
+        Instant notificationTime
+) {
+    public Plan toEntity(Study study, PlanCategory planCategory, RecurringOption recurringOption) {
+        return Plan.builder()
+                .study(study)
+                .planCategory(planCategory)
+                .recurringOption(recurringOption)
+                .title(title)
+                .description(description)
+                .startTime(startTime)
+                .endTime(endTime)
+                .notificationTime(notificationTime)
+                .build();
+    }
+}

--- a/src/main/java/com/flytrap/venusplanner/api/study_plan/presentation/dto/request/StudyPlanCreateRequest.java
+++ b/src/main/java/com/flytrap/venusplanner/api/study_plan/presentation/dto/request/StudyPlanCreateRequest.java
@@ -5,17 +5,16 @@ import com.flytrap.venusplanner.api.plan.domain.RecurringOption;
 import com.flytrap.venusplanner.api.plan_category.domain.PlanCategory;
 import com.flytrap.venusplanner.api.study.domain.Study;
 import jakarta.validation.constraints.Future;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.Instant;
+import java.util.Optional;
 
 public record StudyPlanCreateRequest(
         @NotNull
         Long categoryId,
 
-        @NotBlank
-        @Size(min = 1, max = 100)
+        @Size(max = 100)
         String title,
 
         @Size(max = 255)
@@ -31,11 +30,15 @@ public record StudyPlanCreateRequest(
         Instant notificationTime,
         RecurringOptionRequest recurringOption
 ) {
-    public Plan toEntity(Study study, PlanCategory planCategory, RecurringOption recurringOption) {
+    public Plan toEntity(Study study, PlanCategory planCategory) {
+        RecurringOption recurringOptionEntity = Optional.ofNullable(recurringOption)
+                .map(RecurringOptionRequest::toEntity)
+                .orElse(null);
+
         return Plan.builder()
                 .study(study)
                 .planCategory(planCategory)
-                .recurringOption(recurringOption)
+                .recurringOption(recurringOptionEntity)
                 .title(title)
                 .description(description)
                 .startTime(startTime)

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -42,7 +42,7 @@ CREATE TABLE `sign_in_type`
 CREATE TABLE `plan`
 (
     `id`                  BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY,
-    `category_id`         BIGINT       NULL,
+    `plan_category_id`         BIGINT       NULL,
     `study_id`            BIGINT       NOT NULL,
     `recurring_option_id` BIGINT       NULL,
     `title`               VARCHAR(100) NULL,
@@ -52,7 +52,7 @@ CREATE TABLE `plan`
     `notification_time`   TIMESTAMP    NULL
 );
 
-CREATE TABLE `category`
+CREATE TABLE `plan_category`
 (
     `id`               BIGINT      NOT NULL AUTO_INCREMENT PRIMARY KEY,
     `study_id`         BIGINT      NOT NULL,

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -45,7 +45,7 @@ CREATE TABLE `plan`
     `plan_category_id`         BIGINT       NULL,
     `study_id`            BIGINT       NOT NULL,
     `recurring_option_id` BIGINT       NULL,
-    `title`               VARCHAR(100) NULL,
+    `title`               VARCHAR(100) NOT NULL,
     `description`         VARCHAR(255) NULL,
     `start_time`          TIMESTAMP    NOT NULL,
     `end_time`            TIMESTAMP    NOT NULL,
@@ -66,8 +66,8 @@ CREATE TABLE `recurring_option`
     `id`               BIGINT                               NOT NULL AUTO_INCREMENT PRIMARY KEY,
     `frequency`        ENUM ("WEEKLY", "MONTHLY", "YEARLY") NOT NULL COMMENT '매주, 매달, 매년',
     `end_option`       ENUM ("DATE", "COUNT")               NOT NULL COMMENT '횟수, 특정 날짜',
-    `recurrence_count` INT                                  NOT NULL,
-    `end_date`         TIMESTAMP                            NOT NULL
+    `recurrence_count` INT                                  NULL,
+    `end_date`         TIMESTAMP                            NULL
 );
 
 CREATE TABLE `permission`


### PR DESCRIPTION
# ✨ Key changes
- [x] #3 
  
# 👋 To reviewers
## 반복 옵션 존재 시 생성 로직 
`Plan` 엔티티가 `RecurringOption` 엔티티를 참조할 때, 해당 엔티티가 영속화 상태에 있어야 합니다. 
현재 로직에서는 
```java
    @Cascade(CascadeType.ALL)
    private RecurringOption recurringOption;
```
이처럼 `cascade` 옵션을 설정하여 `Plan` 엔티티가 저장될 때  `RecurringOption` 엔티티가 저장되도록 설정하였습니다. 
`CascadeType.ALL`로 현재 설정되어 있지만 `Plan`이 삭제될 때, `RecurringOption`이 삭제되지 않을수도 있으므로 `CascadeType.PERSIST`로 변경할 생각입니다. 

`cascade` 옵션을 비선호하는 사람들도 있어 다른 분들의 의견이 궁금합니다. 

### `cascade` 옵션 비사용시 대안
- `Plan` 엔티티 저장 전 `RecurringOption` 엔티티 저장 처리를 해줄 수 있을 것 같습니다.

### 미완성 기능 TODO
- [ ] 반복 옵션 존재 시 해당 반복되는만큼 `plan` 엔티티 추가 저장 로직 구현 
- [ ] 예외처리 (예외 방식이 정해지면 완료하겠습니다.)

## 제목 기본값 추가 
`@PrePersist` & `@PreUpdate` 를 활용해서 엔티티가 영속화됙 전에 유효성 검사 수행하여 기본값 추가 [참고 블로그 링크](https://mindybughunter.com/prepersist%EC%99%80-preupdate%EB%A5%BC-%ED%86%B5%ED%95%9C-%ED%9A%A8%EC%9C%A8%EC%A0%81%EC%9D%B8-%EB%8D%B0%EC%9D%B4%ED%84%B0-%EB%AC%B4%EA%B2%B0%EC%84%B1-%EA%B4%80%EB%A6%AC/)

