### PR TITLE
[feat] `Study` 생성 API 구현

### DIFF
--- a/src/main/java/com/flytrap/venusplanner/api/access/domain/Permission.java
+++ b/src/main/java/com/flytrap/venusplanner/api/access/domain/Permission.java
@@ -1,0 +1,18 @@
+package com.flytrap.venusplanner.api.access.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum Permission {
+
+    NONE(1L, "NONE"),
+    EDIT(2L, "EDIT");
+
+    private final Long id;
+    private final String name;
+
+    Permission(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+}

--- a/src/main/java/com/flytrap/venusplanner/api/access/domain/Roll.java
+++ b/src/main/java/com/flytrap/venusplanner/api/access/domain/Roll.java
@@ -1,0 +1,18 @@
+package com.flytrap.venusplanner.api.access.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum Roll {
+
+    LEADER(1L, "LEADER"),
+    MEMBER(2L, "MEMBER");
+
+    private final Long id;
+    private final String name;
+
+    Roll(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+}

--- a/src/main/java/com/flytrap/venusplanner/api/member_study/business/service/MemberStudyService.java
+++ b/src/main/java/com/flytrap/venusplanner/api/member_study/business/service/MemberStudyService.java
@@ -1,0 +1,25 @@
+package com.flytrap.venusplanner.api.member_study.business.service;
+
+import com.flytrap.venusplanner.api.member_study.domain.MemberStudy;
+import com.flytrap.venusplanner.api.member_study.infrastructure.repository.MemberStudyRepository;
+import com.flytrap.venusplanner.api.study.domain.Study;
+import com.flytrap.venusplanner.global.auth.dto.SessionMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberStudyService {
+
+    private final MemberStudyRepository memberStudyRepository;
+
+    public void saveLeaderStudy(SessionMember leader, Study study) {
+        MemberStudy memberStudy = MemberStudy.fromLeader(
+                leader.id(),
+                study
+        );
+        memberStudyRepository.save(memberStudy);
+    }
+}

--- a/src/main/java/com/flytrap/venusplanner/api/member_study/domain/MemberStudy.java
+++ b/src/main/java/com/flytrap/venusplanner/api/member_study/domain/MemberStudy.java
@@ -1,0 +1,50 @@
+package com.flytrap.venusplanner.api.member_study.domain;
+
+import com.flytrap.venusplanner.api.access.domain.Permission;
+import com.flytrap.venusplanner.api.access.domain.Roll;
+import com.flytrap.venusplanner.api.study.domain.Study;
+import com.flytrap.venusplanner.global.entity.TimeAuditingBaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberStudy extends TimeAuditingBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long memberId;
+
+    @ManyToOne
+    private Study study;
+
+    private Long rollId;
+    private Long permissionId;
+
+    @Builder
+    private MemberStudy(Long memberId, Study study, Long rollId, Long permissionId) {
+        this.memberId = memberId;
+        this.study = study;
+        this.rollId = rollId;
+        this.permissionId = permissionId;
+    }
+
+    public static MemberStudy fromLeader(Long leaderId, Study study) {
+        return MemberStudy.builder()
+                .memberId(leaderId)
+                .study(study)
+                .rollId(Roll.LEADER.getId())
+                .permissionId(Permission.EDIT.getId())
+                .build();
+    }
+}

--- a/src/main/java/com/flytrap/venusplanner/api/member_study/infrastructure/repository/MemberStudyRepository.java
+++ b/src/main/java/com/flytrap/venusplanner/api/member_study/infrastructure/repository/MemberStudyRepository.java
@@ -1,0 +1,9 @@
+package com.flytrap.venusplanner.api.member_study.infrastructure.repository;
+
+import com.flytrap.venusplanner.api.member_study.domain.MemberStudy;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberStudyRepository extends JpaRepository<MemberStudy, Long> {
+}

--- a/src/main/java/com/flytrap/venusplanner/api/study/business/service/MemberStudyFacadeService.java
+++ b/src/main/java/com/flytrap/venusplanner/api/study/business/service/MemberStudyFacadeService.java
@@ -1,0 +1,26 @@
+package com.flytrap.venusplanner.api.study.business.service;
+
+import com.flytrap.venusplanner.api.member_study.business.service.MemberStudyService;
+import com.flytrap.venusplanner.api.study.domain.Study;
+import com.flytrap.venusplanner.api.study.presentation.dto.StudyCreateDto;
+import com.flytrap.venusplanner.global.auth.dto.SessionMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberStudyFacadeService {
+
+    private final StudyService studyService;
+    private final MemberStudyService memberStudyService;
+
+    @Transactional
+    public Study saveLeaderStudy(SessionMember leader, StudyCreateDto.Request request) {
+        Study study = studyService.saveStudy(request.toEntity());
+        memberStudyService.saveLeaderStudy(leader, study);
+
+        return study;
+    }
+}

--- a/src/main/java/com/flytrap/venusplanner/api/study/business/service/StudyService.java
+++ b/src/main/java/com/flytrap/venusplanner/api/study/business/service/StudyService.java
@@ -13,6 +13,11 @@ public class StudyService {
 
     private final StudyRepository studyRepository;
 
+    @Transactional
+    public Study saveStudy(Study study) {
+        return studyRepository.save(study);
+    }
+
     public Study findById(Long studyId) {
         //TODO: optional null 처리
         return studyRepository.findById(studyId).get();

--- a/src/main/java/com/flytrap/venusplanner/api/study/domain/Study.java
+++ b/src/main/java/com/flytrap/venusplanner/api/study/domain/Study.java
@@ -1,11 +1,11 @@
 package com.flytrap.venusplanner.api.study.domain;
 
+import com.flytrap.venusplanner.global.entity.TimeAuditingBaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotNull;
-import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Study {
+public class Study extends TimeAuditingBaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -21,6 +21,11 @@ public class Study {
 
     @NotNull
     private String name;
+
     private String description;
-    private Instant createdTime;
+
+    public Study(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
 }

--- a/src/main/java/com/flytrap/venusplanner/api/study/presentation/controller/StudyController.java
+++ b/src/main/java/com/flytrap/venusplanner/api/study/presentation/controller/StudyController.java
@@ -1,8 +1,10 @@
 package com.flytrap.venusplanner.api.study.presentation.controller;
 
-import com.flytrap.venusplanner.api.study.business.service.StudyService;
+import com.flytrap.venusplanner.api.study.business.service.MemberStudyFacadeService;
 import com.flytrap.venusplanner.api.study.domain.Study;
 import com.flytrap.venusplanner.api.study.presentation.dto.StudyCreateDto;
+import com.flytrap.venusplanner.global.auth.annotation.SignIn;
+import com.flytrap.venusplanner.global.auth.dto.SessionMember;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,13 +17,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class StudyController {
 
-    private final StudyService studyService;
+    private final MemberStudyFacadeService memberStudyFacadeService;
 
     @PostMapping("/api/v1/studies")
     public ResponseEntity<StudyCreateDto.Response> createStudy(
+            @SignIn SessionMember leader,
             @Valid @RequestBody StudyCreateDto.Request request
     ) {
-        Study study = studyService.saveStudy(request.toEntity());
+        Study study = memberStudyFacadeService.saveLeaderStudy(leader, request);
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(StudyCreateDto.Response.from(study));

--- a/src/main/java/com/flytrap/venusplanner/api/study/presentation/controller/StudyController.java
+++ b/src/main/java/com/flytrap/venusplanner/api/study/presentation/controller/StudyController.java
@@ -1,0 +1,29 @@
+package com.flytrap.venusplanner.api.study.presentation.controller;
+
+import com.flytrap.venusplanner.api.study.business.service.StudyService;
+import com.flytrap.venusplanner.api.study.domain.Study;
+import com.flytrap.venusplanner.api.study.presentation.dto.StudyCreateDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class StudyController {
+
+    private final StudyService studyService;
+
+    @PostMapping("/api/v1/studies")
+    public ResponseEntity<StudyCreateDto.Response> createStudy(
+            @Valid @RequestBody StudyCreateDto.Request request
+    ) {
+        Study study = studyService.saveStudy(request.toEntity());
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(StudyCreateDto.Response.from(study));
+    }
+}

--- a/src/main/java/com/flytrap/venusplanner/api/study/presentation/dto/StudyCreateDto.java
+++ b/src/main/java/com/flytrap/venusplanner/api/study/presentation/dto/StudyCreateDto.java
@@ -1,0 +1,34 @@
+package com.flytrap.venusplanner.api.study.presentation.dto;
+
+import com.flytrap.venusplanner.api.study.domain.Study;
+import jakarta.validation.constraints.Size;
+
+public record StudyCreateDto(
+) {
+    public record Request(
+
+            @Size(min = 1, max = 100, message = "이름은 1~100자 사이로 입력 가능합니다.")
+            String name,
+
+            String description
+    ) {
+        public Study toEntity() {
+            return new Study(
+                    name,
+                    description
+            );
+        }
+    }
+
+    public record Response(
+            Long id,
+            String name
+    ) {
+        public static Response from(Study study) {
+            return new Response(
+                    study.getId(),
+                    study.getName()
+            );
+        }
+    }
+}

--- a/src/main/java/com/flytrap/venusplanner/global/config/JpaAuditConfig.java
+++ b/src/main/java/com/flytrap/venusplanner/global/config/JpaAuditConfig.java
@@ -1,0 +1,9 @@
+package com.flytrap.venusplanner.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditConfig {
+}

--- a/src/main/java/com/flytrap/venusplanner/global/entity/TimeAuditingBaseEntity.java
+++ b/src/main/java/com/flytrap/venusplanner/global/entity/TimeAuditingBaseEntity.java
@@ -1,0 +1,19 @@
+package com.flytrap.venusplanner.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.Instant;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class TimeAuditingBaseEntity {
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private Instant createdTime;
+}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -13,7 +13,7 @@ CREATE TABLE `member_study`
     `study_id`          BIGINT    NOT NULL,
     `roll_id`           BIGINT    NOT NULL,
     `permission_id`     BIGINT    NOT NULL,
-    `registration_time` TIMESTAMP NOT NULL
+    `created_time`      TIMESTAMP NOT NULL
 );
 
 CREATE TABLE `member`


### PR DESCRIPTION
# ✨ Key changes
- [X] #27 
  
# 👋 To reviewers
- 스터디 생성 시, 스터디를 생성한 회원의 `MemberStudy`가 리더 권한으로 생성되도록 구현했습니다.
- 테스트 코드를 작성하고 싶었는데, 에이프가 개발하시는 쪽이랑 공통으로 사용하는 도메인이 있어서 우선 PR 올리게 되었습니다.
- 테스트 코드는 차주에 작성하도록 하겠습니다.

## `TimeAuditingBaseEntity`
- `TimeAuditingBaseEntity`를 구현했습니다.
- 아직은 `createdTime`밖에 없지만 필요 시 수정 시간 관련 필드가 추가될 수 있을 것 같습니다.
- `createdTime`이 필요한 엔티티가 있으면 상속받으면 됩니다.
- `MemberStudy` 필드에 `registrationTime`이 사실상 생성 시간이라서 `createdTime`으로 수정했습니다.

## 권한 & 역할
- 권한과 역할 관련 정책이 픽스되지 않아서 우선은 이넘으로 구현했습니다.
- 상세 명세가 정해지면 필요 시 엔티티로 수정하면 될 것 같습니다.

## 파사드 위치
- 스터디 생성 시, `Study` 도메인과 `MemberStudy` 도메인이 필요합니다.
- 이에 따라 파사드서비스를 만들었는데... 파사드가 어디에 위치해야 할지 애매하더라구요...
- 그래서 일단은 `Study` 패키지에 넣어두었는데 의견 주시면 감사하겠습니다.