### PR TITLE
[feat] GlobalExceptionHanlder 추가 요구 사항 구현

### DIFF
--- a/src/main/java/com/flytrap/venusplanner/api/auth_member/exception/AuthMemberExceptionType.java
+++ b/src/main/java/com/flytrap/venusplanner/api/auth_member/exception/AuthMemberExceptionType.java
@@ -1,0 +1,12 @@
+package com.flytrap.venusplanner.api.auth_member.exception;
+
+import com.flytrap.venusplanner.global.exception.CustomException;
+import com.flytrap.venusplanner.global.exception.GeneralExceptionType;
+
+public class AuthMemberExceptionType extends GeneralExceptionType {
+
+    public static CustomException GITHUB_OAUTH_REQUEST_FAILURE_EXCEPTION(String message) {
+        return API_REQUEST_FAILURE_EXCEPTION(message);
+    }
+
+}

--- a/src/main/java/com/flytrap/venusplanner/api/auth_member/exception/AuthMemberExceptionType.java
+++ b/src/main/java/com/flytrap/venusplanner/api/auth_member/exception/AuthMemberExceptionType.java
@@ -5,8 +5,8 @@ import com.flytrap.venusplanner.global.exception.GeneralExceptionType;
 
 public class AuthMemberExceptionType extends GeneralExceptionType {
 
-    public static CustomException GITHUB_OAUTH_REQUEST_FAILURE_EXCEPTION(String message) {
-        return API_REQUEST_FAILURE_EXCEPTION(message);
+    public static CustomException GitHubOauthRequestFailureException(String message) {
+        return ApiRequestFailureException(message);
     }
 
 }

--- a/src/main/java/com/flytrap/venusplanner/api/auth_member/exception/GitHubOAuthRequestException.java
+++ b/src/main/java/com/flytrap/venusplanner/api/auth_member/exception/GitHubOAuthRequestException.java
@@ -1,7 +1,0 @@
-package com.flytrap.venusplanner.api.auth_member.exception;
-
-public class GitHubOAuthRequestException extends RuntimeException {
-    public GitHubOAuthRequestException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/flytrap/venusplanner/api/auth_member/infrastructure/external/GitHubOAuthProvider.java
+++ b/src/main/java/com/flytrap/venusplanner/api/auth_member/infrastructure/external/GitHubOAuthProvider.java
@@ -1,11 +1,12 @@
 package com.flytrap.venusplanner.api.auth_member.infrastructure.external;
 
-import com.flytrap.venusplanner.global.auth.config.OAuthWebClientConfig.GitHubOAuthFormDataBuilder;
-import com.flytrap.venusplanner.api.auth_member.exception.GitHubOAuthRequestException;
+import static com.flytrap.venusplanner.api.auth_member.exception.AuthMemberExceptionType.GITHUB_OAUTH_REQUEST_FAILURE_EXCEPTION;
+
 import com.flytrap.venusplanner.api.auth_member.infrastructure.dto.AccessTokenFromGitHub;
 import com.flytrap.venusplanner.api.auth_member.infrastructure.dto.StandardizedUserResource;
 import com.flytrap.venusplanner.api.auth_member.infrastructure.dto.UserEmailResourceFromGitHub;
 import com.flytrap.venusplanner.api.auth_member.infrastructure.dto.UserResourceFromGitHub;
+import com.flytrap.venusplanner.global.auth.config.OAuthWebClientConfig.GitHubOAuthFormDataBuilder;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,8 +34,6 @@ public class GitHubOAuthProvider implements OAuthProvider {
      * <p>
      * @param code GitHub OAuth 인증 과정에서 얻은 인증 코드
      * @return 사용자 정보를 담고 있는 {@link StandardizedUserResource} 객체입니다.
-     * @throws GitHubOAuthRequestException GitHub 요청 과정에서 오류가 발생했을 때 발생합니다.
-     * 이는 네트워크 문제, 데이터 포맷 문제, 서버 측 오류 등 다양한 이유로 발생할 수 있습니다.
      */
     public StandardizedUserResource authenticateAndFetchUserResource(String code) {
 
@@ -48,13 +47,10 @@ public class GitHubOAuthProvider implements OAuthProvider {
      * GitHub OAuth 서버로부터 액세스 토큰을 요청합니다.
      * <p>
      * 이 메서드는 매개변수로 주어진 인증 코드를 사용하여 GitHub OAuth 서버에 액세스 토큰을 요청합니다. 요청이 성공하면, 액세스 토큰이 담긴
-     * {@link AccessTokenFromGitHub} 객체를 반환합니다. 요청 중 발생하는 모든 4xx 및 5xx HTTP 응답 코드는
-     * {@link GitHubOAuthRequestException}을 발생시킵니다.
+     * {@link AccessTokenFromGitHub} 객체를 반환합니다. 요청 중 발생하는 모든 4xx 및 5xx HTTP 응답 코드는 예외를 발생시킵니다.
      * <p>
      * @param code GitHub OAuth 인증 과정에서 얻은 인증 코드
      * @return 액세스 토큰 정보를 담고 있는 {@link AccessTokenFromGitHub}
-     * @throws GitHubOAuthRequestException GitHub OAuth 요청 과정에서 발생하는 모든 예외를 포함합니다.
-     * 이는 네트워크 문제, 데이터 포맷 문제, 서버 측 오류 등을 포함할 수 있습니다.
      */
     private AccessTokenFromGitHub requestAccessToken(String code) {
 
@@ -70,10 +66,10 @@ public class GitHubOAuthProvider implements OAuthProvider {
                 .onStatus(
                         statusCode -> statusCode.is4xxClientError() || statusCode.is5xxServerError(),
                         response -> response.bodyToMono(String.class)
-                                        .flatMap(body -> Mono.error(new GitHubOAuthRequestException(body))))
+                                        .flatMap(body -> Mono.error(GITHUB_OAUTH_REQUEST_FAILURE_EXCEPTION(body))))
                 .bodyToMono(AccessTokenFromGitHub.class)
                 .doOnError(error -> log.error("GitHub에서 액세스 토큰을 요청하는 중 에러 발생", error))
-                .onErrorMap(throwable -> new GitHubOAuthRequestException(throwable.getMessage()))
+                .onErrorMap(throwable -> GITHUB_OAUTH_REQUEST_FAILURE_EXCEPTION(throwable.getMessage()))
                 .block();
     }
 
@@ -81,14 +77,11 @@ public class GitHubOAuthProvider implements OAuthProvider {
      * GitHub에서 사용자 정보를 요청합니다.
      * <p>
      * 이 메서드는 주어진 액세스 토큰을 사용하여 GitHub의 사용자 정보 리소스에 대한 GET 요청을 실행합니다. 요청이 성공하면,
-     * {@link UserResourceFromGitHub} 객체를 반환합니다. 요청 중에 4xx 또는 5xx HTTP 상태 코드가 반환되는 경우,
-     * {@link GitHubOAuthRequestException}을 발생시킵니다.
+     * {@link UserResourceFromGitHub} 객체를 반환합니다. 요청 중에 4xx 또는 5xx HTTP 상태 코드가 반환되는 경우, 예외를 발생시킵니다.
      * <p>
      *
      * @param accessToken GitHub OAuth를 통해 얻은 액세스 토큰, {@link AccessTokenFromGitHub} 객체입니다.
      * @return 사용자 정보를 담고 있는 {@link UserResourceFromGitHub} 객체입니다. 사용자 정보에 이메일이 포함됩니다.
-     * @throws GitHubOAuthRequestException GitHub 요청 과정에서 오류가 발생했을 때 발생합니다.
-     * 이는 네트워크 문제, 데이터 포맷 문제, 서버 측 오류 등 다양한 이유로 발생할 수 있습니다.
      */
     private UserResourceFromGitHub requestUserResource(AccessTokenFromGitHub accessToken) {
 
@@ -100,7 +93,7 @@ public class GitHubOAuthProvider implements OAuthProvider {
                 .onStatus(
                         statusCode -> statusCode.is4xxClientError() || statusCode.is5xxServerError(),
                         response -> response.bodyToMono(String.class)
-                                .flatMap(body -> Mono.error(new GitHubOAuthRequestException(body))))
+                                .flatMap(body -> Mono.error(GITHUB_OAUTH_REQUEST_FAILURE_EXCEPTION(body))))
                 .bodyToMono(UserResourceFromGitHub.class)
                 .flatMap(userResource -> {
                     if (userResource.isEmailEmpty()) {
@@ -115,7 +108,7 @@ public class GitHubOAuthProvider implements OAuthProvider {
                     return Mono.just(userResource);
                 })
                 .doOnError(error -> log.error("GitHub에서 회원 정보를 요청하는 중 에러 발생", error))
-                .onErrorMap(throwable -> new GitHubOAuthRequestException(throwable.getMessage()))
+                .onErrorMap(throwable -> GITHUB_OAUTH_REQUEST_FAILURE_EXCEPTION(throwable.getMessage()))
                 .block();
     }
 
@@ -124,16 +117,12 @@ public class GitHubOAuthProvider implements OAuthProvider {
      * <p>
      * 이 메서드는 주어진 액세스 토큰을 사용하여 GitHub의 사용자 이메일 정보 리소스에 대한 GET 요청을 실행합니다.
      * 요청이 성공하면, 이메일 정보 목록 중 첫 번째 이메일 주소를 문자열로 반환합니다. 만약 이메일 정보 목록이 비어 있으면,
-     * 빈 문자열을 반환합니다. 요청 중에 4xx 또는 5xx HTTP 상태 코드가 반환되는 경우,
-     * {@link GitHubOAuthRequestException}을 Mono.error()로 반환합니다.
+     * 빈 문자열을 반환합니다. 요청 중에 4xx 또는 5xx HTTP 상태 코드가 반환되는 경우, 예외를 Mono.error()로 반환합니다.
      * <p>
      * GitHub에서 사용자 정보를 요청할 때 email은 비공개 설정일 경우 반환하지 않기 때문에 이 메서드로 email을 추가 요청해야 합니다.
      * <p>
      * @param accessToken GitHub OAuth를 통해 얻은 액세스 토큰, {@link AccessTokenFromGitHub} 객체입니다.
      * @return 사용자의 첫 번째 이메일 주소를 담고 있는 문자열의 Mono입니다. 이메일 목록이 비어 있을 경우 빈 문자열을 반환합니다.
-     * @throws GitHubOAuthRequestException GitHub 요청 과정에서 오류가 발생했을 때 발생합니다.
-     * 이는 네트워크 문제, 데이터 포맷 문제, 서버 측 오류 등 다양한 이유로 발생할 수 있습니다.
-     * <p>
      */
     private Mono<String> requestPrimaryUserEmailResource(AccessTokenFromGitHub accessToken) {
 
@@ -146,11 +135,11 @@ public class GitHubOAuthProvider implements OAuthProvider {
                 .onStatus(
                         statusCode -> statusCode.is4xxClientError() || statusCode.is5xxServerError(),
                         response -> response.bodyToMono(String.class)
-                                .flatMap(body -> Mono.error(new GitHubOAuthRequestException(body))))
+                                .flatMap(body -> Mono.error(GITHUB_OAUTH_REQUEST_FAILURE_EXCEPTION(body))))
                 .bodyToMono(new ParameterizedTypeReference<List<UserEmailResourceFromGitHub>>() {})
                 .map(emailList -> emailList.isEmpty() ? "" : emailList.get(0).email())
                 .doOnError(error -> log.error("GitHub에서 이메일 정보를 요청하는 중 에러 발생", error))
-                .onErrorMap(throwable -> new GitHubOAuthRequestException(throwable.getMessage()));
+                .onErrorMap(throwable -> GITHUB_OAUTH_REQUEST_FAILURE_EXCEPTION(throwable.getMessage()));
     }
 
 }

--- a/src/main/java/com/flytrap/venusplanner/api/auth_member/infrastructure/external/GitHubOAuthProvider.java
+++ b/src/main/java/com/flytrap/venusplanner/api/auth_member/infrastructure/external/GitHubOAuthProvider.java
@@ -1,6 +1,6 @@
 package com.flytrap.venusplanner.api.auth_member.infrastructure.external;
 
-import static com.flytrap.venusplanner.api.auth_member.exception.AuthMemberExceptionType.GITHUB_OAUTH_REQUEST_FAILURE_EXCEPTION;
+import static com.flytrap.venusplanner.api.auth_member.exception.AuthMemberExceptionType.GitHubOauthRequestFailureException;
 
 import com.flytrap.venusplanner.api.auth_member.infrastructure.dto.AccessTokenFromGitHub;
 import com.flytrap.venusplanner.api.auth_member.infrastructure.dto.StandardizedUserResource;
@@ -66,10 +66,10 @@ public class GitHubOAuthProvider implements OAuthProvider {
                 .onStatus(
                         statusCode -> statusCode.is4xxClientError() || statusCode.is5xxServerError(),
                         response -> response.bodyToMono(String.class)
-                                        .flatMap(body -> Mono.error(GITHUB_OAUTH_REQUEST_FAILURE_EXCEPTION(body))))
+                                        .flatMap(body -> Mono.error(GitHubOauthRequestFailureException(body))))
                 .bodyToMono(AccessTokenFromGitHub.class)
                 .doOnError(error -> log.error("GitHub에서 액세스 토큰을 요청하는 중 에러 발생", error))
-                .onErrorMap(throwable -> GITHUB_OAUTH_REQUEST_FAILURE_EXCEPTION(throwable.getMessage()))
+                .onErrorMap(throwable -> GitHubOauthRequestFailureException(throwable.getMessage()))
                 .block();
     }
 
@@ -93,7 +93,7 @@ public class GitHubOAuthProvider implements OAuthProvider {
                 .onStatus(
                         statusCode -> statusCode.is4xxClientError() || statusCode.is5xxServerError(),
                         response -> response.bodyToMono(String.class)
-                                .flatMap(body -> Mono.error(GITHUB_OAUTH_REQUEST_FAILURE_EXCEPTION(body))))
+                                .flatMap(body -> Mono.error(GitHubOauthRequestFailureException(body))))
                 .bodyToMono(UserResourceFromGitHub.class)
                 .flatMap(userResource -> {
                     if (userResource.isEmailEmpty()) {
@@ -108,7 +108,7 @@ public class GitHubOAuthProvider implements OAuthProvider {
                     return Mono.just(userResource);
                 })
                 .doOnError(error -> log.error("GitHub에서 회원 정보를 요청하는 중 에러 발생", error))
-                .onErrorMap(throwable -> GITHUB_OAUTH_REQUEST_FAILURE_EXCEPTION(throwable.getMessage()))
+                .onErrorMap(throwable -> GitHubOauthRequestFailureException(throwable.getMessage()))
                 .block();
     }
 
@@ -135,11 +135,11 @@ public class GitHubOAuthProvider implements OAuthProvider {
                 .onStatus(
                         statusCode -> statusCode.is4xxClientError() || statusCode.is5xxServerError(),
                         response -> response.bodyToMono(String.class)
-                                .flatMap(body -> Mono.error(GITHUB_OAUTH_REQUEST_FAILURE_EXCEPTION(body))))
+                                .flatMap(body -> Mono.error(GitHubOauthRequestFailureException(body))))
                 .bodyToMono(new ParameterizedTypeReference<List<UserEmailResourceFromGitHub>>() {})
                 .map(emailList -> emailList.isEmpty() ? "" : emailList.get(0).email())
                 .doOnError(error -> log.error("GitHub에서 이메일 정보를 요청하는 중 에러 발생", error))
-                .onErrorMap(throwable -> GITHUB_OAUTH_REQUEST_FAILURE_EXCEPTION(throwable.getMessage()));
+                .onErrorMap(throwable -> GitHubOauthRequestFailureException(throwable.getMessage()));
     }
 
 }

--- a/src/main/java/com/flytrap/venusplanner/api/member/domain/Member.java
+++ b/src/main/java/com/flytrap/venusplanner/api/member/domain/Member.java
@@ -8,10 +8,12 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
@@ -38,6 +40,9 @@ public class Member extends TimeAuditingBaseEntity {
 
     @NotNull
     private String nickname;
+
+    @CreatedDate
+    private Instant createdTime;
 
     @Builder
     private Member(String oauthPk, Long oauthPlatformId, String email, String profileImageUrl, String nickname) {

--- a/src/main/java/com/flytrap/venusplanner/api/member/domain/OAuthPlatformType.java
+++ b/src/main/java/com/flytrap/venusplanner/api/member/domain/OAuthPlatformType.java
@@ -1,6 +1,7 @@
 package com.flytrap.venusplanner.api.member.domain;
 
-import com.flytrap.venusplanner.api.member.exception.UnknownOAuthPlatformType;
+import static com.flytrap.venusplanner.api.member.exception.MemberExceptionType.NO_SUCH_OAUTH_PLATFORM_TYPE_EXCEPTION;
+
 import java.util.Arrays;
 import java.util.Objects;
 import lombok.Getter;
@@ -17,7 +18,7 @@ public enum OAuthPlatformType {
         return Arrays.stream(OAuthPlatformType.values())
                 .filter(type -> Objects.equals(type.name(), name))
                 .findFirst()
-                .orElseThrow(() -> new UnknownOAuthPlatformType(name));
+                .orElseThrow(() -> NO_SUCH_OAUTH_PLATFORM_TYPE_EXCEPTION(name));
     }
 
 }

--- a/src/main/java/com/flytrap/venusplanner/api/member/domain/OAuthPlatformType.java
+++ b/src/main/java/com/flytrap/venusplanner/api/member/domain/OAuthPlatformType.java
@@ -1,6 +1,6 @@
 package com.flytrap.venusplanner.api.member.domain;
 
-import static com.flytrap.venusplanner.api.member.exception.MemberExceptionType.NO_SUCH_OAUTH_PLATFORM_TYPE_EXCEPTION;
+import static com.flytrap.venusplanner.api.member.exception.MemberExceptionType.NoSuchOauthPlatformTypeException;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -18,7 +18,7 @@ public enum OAuthPlatformType {
         return Arrays.stream(OAuthPlatformType.values())
                 .filter(type -> Objects.equals(type.name(), name))
                 .findFirst()
-                .orElseThrow(() -> NO_SUCH_OAUTH_PLATFORM_TYPE_EXCEPTION(name));
+                .orElseThrow(() -> NoSuchOauthPlatformTypeException(name));
     }
 
 }

--- a/src/main/java/com/flytrap/venusplanner/api/member/exception/MemberExceptionType.java
+++ b/src/main/java/com/flytrap/venusplanner/api/member/exception/MemberExceptionType.java
@@ -1,0 +1,22 @@
+package com.flytrap.venusplanner.api.member.exception;
+
+import com.flytrap.venusplanner.api.member.domain.Member;
+import com.flytrap.venusplanner.api.member.domain.OAuthPlatformType;
+import com.flytrap.venusplanner.global.exception.CustomException;
+import com.flytrap.venusplanner.global.exception.GeneralExceptionType;
+
+public class MemberExceptionType extends GeneralExceptionType {
+
+    public static CustomException MEMBER_NOT_FOUND_EXCEPTION() {
+        return DOMAIN_NOT_FOUND_EXCEPTION(Member.class);
+    }
+
+    public static CustomException MEMBER_NOT_FOUND_EXCEPTION(Long domainId) {
+        return DOMAIN_NOT_FOUND_EXCEPTION(Member.class, domainId);
+    }
+
+    public static CustomException NO_SUCH_OAUTH_PLATFORM_TYPE_EXCEPTION(String mismatchedTypeName) {
+        return NO_SUCH_ENUM_TYPE_EXCEPTION(OAuthPlatformType.class, mismatchedTypeName);
+    }
+
+}

--- a/src/main/java/com/flytrap/venusplanner/api/member/exception/MemberExceptionType.java
+++ b/src/main/java/com/flytrap/venusplanner/api/member/exception/MemberExceptionType.java
@@ -7,16 +7,16 @@ import com.flytrap.venusplanner.global.exception.GeneralExceptionType;
 
 public class MemberExceptionType extends GeneralExceptionType {
 
-    public static CustomException MEMBER_NOT_FOUND_EXCEPTION() {
-        return DOMAIN_NOT_FOUND_EXCEPTION(Member.class);
+    public static CustomException MemberNotFoundException() {
+        return DomainNotFoundException(Member.class);
     }
 
-    public static CustomException MEMBER_NOT_FOUND_EXCEPTION(Long domainId) {
-        return DOMAIN_NOT_FOUND_EXCEPTION(Member.class, domainId);
+    public static CustomException MemberNotFoundException(Long domainId) {
+        return DomainNotFoundException(Member.class, domainId);
     }
 
-    public static CustomException NO_SUCH_OAUTH_PLATFORM_TYPE_EXCEPTION(String mismatchedTypeName) {
-        return NO_SUCH_ENUM_TYPE_EXCEPTION(OAuthPlatformType.class, mismatchedTypeName);
+    public static CustomException NoSuchOauthPlatformTypeException(String mismatchedTypeName) {
+        return NoSuchEnumTypeException(OAuthPlatformType.class, mismatchedTypeName);
     }
 
 }

--- a/src/main/java/com/flytrap/venusplanner/api/member/exception/UnknownOAuthPlatformType.java
+++ b/src/main/java/com/flytrap/venusplanner/api/member/exception/UnknownOAuthPlatformType.java
@@ -1,7 +1,0 @@
-package com.flytrap.venusplanner.api.member.exception;
-
-public class UnknownOAuthPlatformType extends RuntimeException {
-    public UnknownOAuthPlatformType(String typeName) {
-        super(typeName + "은(는) 알 수 없는 플랫폼 명 입니다.");
-    }
-}

--- a/src/main/java/com/flytrap/venusplanner/global/auth/exception/SessionMemberAuthException.java
+++ b/src/main/java/com/flytrap/venusplanner/global/auth/exception/SessionMemberAuthException.java
@@ -1,7 +1,0 @@
-package com.flytrap.venusplanner.global.auth.exception;
-
-public class SessionMemberAuthException extends RuntimeException {
-    public SessionMemberAuthException() {
-        super("로그인이 필요한 기능입니다.");
-    }
-}

--- a/src/main/java/com/flytrap/venusplanner/global/auth/resolver/SignInArgumentResolver.java
+++ b/src/main/java/com/flytrap/venusplanner/global/auth/resolver/SignInArgumentResolver.java
@@ -1,8 +1,9 @@
 package com.flytrap.venusplanner.global.auth.resolver;
 
-import com.flytrap.venusplanner.global.auth.dto.SessionMember;
+import static com.flytrap.venusplanner.global.exception.GeneralExceptionType.AUTHENTICATION_FAILURE_EXCEPTION;
+
 import com.flytrap.venusplanner.global.auth.annotation.SignIn;
-import com.flytrap.venusplanner.global.auth.exception.SessionMemberAuthException;
+import com.flytrap.venusplanner.global.auth.dto.SessionMember;
 import com.flytrap.venusplanner.global.auth.properties.AuthSessionProperties;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
@@ -37,15 +38,15 @@ public class SignInArgumentResolver implements HandlerMethodArgumentResolver {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
 
         return extractSessionMember(request)
-                .orElseThrow(SessionMemberAuthException::new);
+                .orElseThrow(() -> AUTHENTICATION_FAILURE_EXCEPTION("세션 정보가 없습니다. 로그인 해주세요."));
     }
 
     private Optional<SessionMember> extractSessionMember(HttpServletRequest request) {
 
-        HttpSession httpSession = request.getSession(false);
+        HttpSession session = request.getSession(false);
 
-        return Optional.ofNullable(httpSession)
-                .map(session -> session.getAttribute(authSessionProperties.sessionName()))
+        return Optional.ofNullable(session)
+                .map(s -> s.getAttribute(authSessionProperties.sessionName()))
                 .filter(SessionMember.class::isInstance)
                 .map(SessionMember.class::cast);
     }

--- a/src/main/java/com/flytrap/venusplanner/global/auth/resolver/SignInArgumentResolver.java
+++ b/src/main/java/com/flytrap/venusplanner/global/auth/resolver/SignInArgumentResolver.java
@@ -1,6 +1,6 @@
 package com.flytrap.venusplanner.global.auth.resolver;
 
-import static com.flytrap.venusplanner.global.exception.GeneralExceptionType.AUTHENTICATION_FAILURE_EXCEPTION;
+import static com.flytrap.venusplanner.global.exception.GeneralExceptionType.AuthenticationFailureException;
 
 import com.flytrap.venusplanner.global.auth.annotation.SignIn;
 import com.flytrap.venusplanner.global.auth.dto.SessionMember;
@@ -38,7 +38,7 @@ public class SignInArgumentResolver implements HandlerMethodArgumentResolver {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
 
         return extractSessionMember(request)
-                .orElseThrow(() -> AUTHENTICATION_FAILURE_EXCEPTION("세션 정보가 없습니다. 로그인 해주세요."));
+                .orElseThrow(() -> AuthenticationFailureException("세션 정보가 없습니다. 로그인 해주세요."));
     }
 
     private Optional<SessionMember> extractSessionMember(HttpServletRequest request) {

--- a/src/main/java/com/flytrap/venusplanner/global/exception/CustomException.java
+++ b/src/main/java/com/flytrap/venusplanner/global/exception/CustomException.java
@@ -1,0 +1,25 @@
+package com.flytrap.venusplanner.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private HttpStatus httpStatus;
+
+    public CustomException(HttpStatus httpStatus) {
+        this.httpStatus = httpStatus;
+    }
+
+    public CustomException(HttpStatus httpStatus, String message) {
+        super(message);
+        this.httpStatus = httpStatus;
+    }
+
+    public CustomException updateHttpStatus(HttpStatus httpStatus) {
+        this.httpStatus = httpStatus;
+
+        return this;
+    }
+}

--- a/src/main/java/com/flytrap/venusplanner/global/exception/ExceptionResponse.java
+++ b/src/main/java/com/flytrap/venusplanner/global/exception/ExceptionResponse.java
@@ -1,0 +1,17 @@
+package com.flytrap.venusplanner.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ExceptionResponse {
+
+    private final String message;
+
+    private ExceptionResponse(String message) {
+        this.message = message;
+    }
+
+    public static ExceptionResponse from(Exception exception) {
+        return new ExceptionResponse(exception.getMessage());
+    }
+}

--- a/src/main/java/com/flytrap/venusplanner/global/exception/GeneralExceptionType.java
+++ b/src/main/java/com/flytrap/venusplanner/global/exception/GeneralExceptionType.java
@@ -1,0 +1,91 @@
+package com.flytrap.venusplanner.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class GeneralExceptionType {
+
+    /**
+     * 일반적인 예외 상황에 사용되는 예외입니다.
+     * <p>
+     * 다른 패키지에 정의될 예외 중 공통 타입으로 묶이지 않는 예외는 이 GENERAL_EXCEPTION을 상속 받으면 됩니다.
+     *
+     * @param httpStatus HTTP 상태 코드
+     * @param message 예외에 대한 메시지
+     * @return CustomException 객체
+     */
+    public static CustomException GENERAL_EXCEPTION(HttpStatus httpStatus, String message) {
+        return new CustomException(httpStatus, message);
+    }
+
+    /**
+     * 어떤 도메인 클래스를 찾을 수 없을 때 사용되는 예외입니다.
+     *
+     * @param domainClazz 찾을 수 없는 도메인 클래스
+     * @return CustomException 객체
+     */
+    public static CustomException DOMAIN_NOT_FOUND_EXCEPTION(Class<?> domainClazz) {
+        return new CustomException(
+                HttpStatus.NOT_FOUND,
+                String.format("[%s] 도메인을 찾을 수 없습니다.", domainClazz.getSimpleName())
+        );
+    }
+
+    /**
+     * 주어진 ID를 가진 도메인 객체를 찾을 수 없을 때 사용되는 예외입니다.
+     *
+     * @param domainClazz 찾을 수 없는 도메인 클래스
+     * @param domainId 찾을 수 없는 도메인 객체의 ID
+     * @return CustomException 객체
+     */
+    public static CustomException DOMAIN_NOT_FOUND_EXCEPTION(Class<?> domainClazz, Long domainId) {
+        return new CustomException(
+                HttpStatus.NOT_FOUND,
+                String.format("[id = %d]에 해당하는 [%s] 도메인을 찾을 수 없습니다.", domainId, domainClazz.getSimpleName())
+        );
+    }
+
+    /**
+     * 주어진 Enum 타입에 존재하지 않는 이름을 사용했을 때 발생하는 예외입니다.
+     *
+     * @param enumClazz 대상 Enum 클래스
+     * @param mismatchedTypeName 존재하지 않는 Enum의 Type 이름
+     * @return CustomException 객체
+     */
+    public static CustomException NO_SUCH_ENUM_TYPE_EXCEPTION(Class<? extends Enum<?>> enumClazz, String mismatchedTypeName) {
+        return new CustomException(
+                HttpStatus.NOT_FOUND,
+                String.format("[%s]은(는) [%s]의 타입이 아닙니다.", mismatchedTypeName, enumClazz.getSimpleName())
+        );
+    }
+
+    /**
+     * 외부 API 요청이 실패했을 때 사용되는 예외입니다.
+     *
+     * @param message 예외에 대한 메시지
+     * @return CustomException 객체
+     */
+    public static CustomException API_REQUEST_FAILURE_EXCEPTION(String message) {
+        return new CustomException(HttpStatus.BAD_GATEWAY, message);
+    }
+
+    /**
+     * 인증 실패 시 사용되는 예외입니다.
+     *
+     * @param message 예외에 대한 메시지
+     * @return CustomException 객체
+     */
+    public static CustomException AUTHENTICATION_FAILURE_EXCEPTION(String message) {
+        return new CustomException(HttpStatus.UNAUTHORIZED, message);
+    }
+
+    /**
+     * 권한이 없는 접근 시 사용되는 예외입니다.
+     *
+     * @param message 예외에 대한 메시지
+     * @return CustomException 객체
+     */
+    public static CustomException FORBIDDEN_EXCEPTION(String message) {
+        return new CustomException(HttpStatus.FORBIDDEN, message);
+    }
+
+}

--- a/src/main/java/com/flytrap/venusplanner/global/exception/GeneralExceptionType.java
+++ b/src/main/java/com/flytrap/venusplanner/global/exception/GeneralExceptionType.java
@@ -13,7 +13,7 @@ public class GeneralExceptionType {
      * @param message 예외에 대한 메시지
      * @return CustomException 객체
      */
-    public static CustomException GENERAL_EXCEPTION(HttpStatus httpStatus, String message) {
+    public static CustomException GeneralException(HttpStatus httpStatus, String message) {
         return new CustomException(httpStatus, message);
     }
 
@@ -23,7 +23,7 @@ public class GeneralExceptionType {
      * @param domainClazz 찾을 수 없는 도메인 클래스
      * @return CustomException 객체
      */
-    public static CustomException DOMAIN_NOT_FOUND_EXCEPTION(Class<?> domainClazz) {
+    public static CustomException DomainNotFoundException(Class<?> domainClazz) {
         return new CustomException(
                 HttpStatus.NOT_FOUND,
                 String.format("[%s] 도메인을 찾을 수 없습니다.", domainClazz.getSimpleName())
@@ -37,7 +37,7 @@ public class GeneralExceptionType {
      * @param domainId 찾을 수 없는 도메인 객체의 ID
      * @return CustomException 객체
      */
-    public static CustomException DOMAIN_NOT_FOUND_EXCEPTION(Class<?> domainClazz, Long domainId) {
+    public static CustomException DomainNotFoundException(Class<?> domainClazz, Long domainId) {
         return new CustomException(
                 HttpStatus.NOT_FOUND,
                 String.format("[id = %d]에 해당하는 [%s] 도메인을 찾을 수 없습니다.", domainId, domainClazz.getSimpleName())
@@ -51,7 +51,7 @@ public class GeneralExceptionType {
      * @param mismatchedTypeName 존재하지 않는 Enum의 Type 이름
      * @return CustomException 객체
      */
-    public static CustomException NO_SUCH_ENUM_TYPE_EXCEPTION(Class<? extends Enum<?>> enumClazz, String mismatchedTypeName) {
+    public static CustomException NoSuchEnumTypeException(Class<? extends Enum<?>> enumClazz, String mismatchedTypeName) {
         return new CustomException(
                 HttpStatus.NOT_FOUND,
                 String.format("[%s]은(는) [%s]의 타입이 아닙니다.", mismatchedTypeName, enumClazz.getSimpleName())
@@ -64,7 +64,7 @@ public class GeneralExceptionType {
      * @param message 예외에 대한 메시지
      * @return CustomException 객체
      */
-    public static CustomException API_REQUEST_FAILURE_EXCEPTION(String message) {
+    public static CustomException ApiRequestFailureException(String message) {
         return new CustomException(HttpStatus.BAD_GATEWAY, message);
     }
 
@@ -74,7 +74,7 @@ public class GeneralExceptionType {
      * @param message 예외에 대한 메시지
      * @return CustomException 객체
      */
-    public static CustomException AUTHENTICATION_FAILURE_EXCEPTION(String message) {
+    public static CustomException AuthenticationFailureException(String message) {
         return new CustomException(HttpStatus.UNAUTHORIZED, message);
     }
 
@@ -84,7 +84,7 @@ public class GeneralExceptionType {
      * @param message 예외에 대한 메시지
      * @return CustomException 객체
      */
-    public static CustomException FORBIDDEN_EXCEPTION(String message) {
+    public static CustomException ForbiddenException(String message) {
         return new CustomException(HttpStatus.FORBIDDEN, message);
     }
 

--- a/src/main/java/com/flytrap/venusplanner/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/flytrap/venusplanner/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,31 @@
+package com.flytrap.venusplanner.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ExceptionResponse> handleException(Exception exception) {
+        log.debug(exception.getMessage());
+
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ExceptionResponse.from(exception));
+    }
+
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<ExceptionResponse> handleCustomException(CustomException exception) {
+        log.debug(exception.getMessage());
+
+        return ResponseEntity
+                .status(exception.getHttpStatus())
+                .body(ExceptionResponse.from(exception));
+    }
+
+}


### PR DESCRIPTION
# ✨ Key changes
- [ ] #16 
  - #22 의 Exception 구조를 개선한 PR 
  

# 👋 To reviewers
## 적용하고자 했던 요구사항
1. 같은 도메인의 예외들 끼리 Enum으로 한 곳에서 관리하고 싶다
2. 예외를 공통 타입으로 도 묶을 수 있어야 한다
3. 예외가 HttpStatus를 가지고 있어야 한다
4. 같은 타입의 예외라도 다른 반환 코드를 가질 수 있어야 한다
5. 예외는 확장 가능해야 한다

### 예외가 확장 가능해야 되는 이유
- 같은 예외여도 상황에 따라 간단한 메세지를 보여줄 수 도 있고, 추가 정보를 넣어주어 더 자세한 메시지를 만들수도 있게 하기 위함

### 요구사항 예시
- MemberNotFoundException이 있다고 가정한다.
- MemberNotFoundException은 DomainNotFoundException라는 공통 타입으로 묶여 있다.
- MemberNotFoundException는 "멤버를 찾을 수 없습니다." 메세지 혹은 "id=1에 해당하는 멤버를 찾을 수 없습니다." 메시지를 가질 수 있다.
  - MemberNotFoundException가 생성될 때 id가 필요한 경우와 필요없는 경우가 있는 것이다
- MemberNotFoundException은 MemberDuplicationException 같은 Member 도메인과 관련된 예외끼리 한 Enum에 관리되고 있다.

## 결과
- Enum으로 확장 가능한 예외를 구현하기 어려워서 class에서 static 메서드를 이용해 예외를 생성하게 했습니다.
- `GeneralExceptionType`에서 공통 타입의 예외를 관리합니다.
-  각 `{domain}.exception` 패키지에 도메인별 `ExepeionType`의 class를 생성해서 도메인별 예외를 생성하는 메서드를 구현합니다.
- 도메인별 `ExepeionType`은 `GeneralExceptionType`을 상속받아 공통 타입 예외 메서드를 재사용할 수 있습니다.

### `CustomException` 구현
- [x] `예외가 HttpStatus를 가지고 있어야 한다`
- [x]  `같은 타입의 예외라도 다른 반환 코드를 가질 수 있어야 한다` -> 공통 타입 예외에서 응답 코드가 정해져 있어도 `updateHttpStatus()`메서드를 사용해 코드를 변경할 수 있다.

  ```java
  @Getter
  public class CustomException extends RuntimeException {

    private HttpStatus httpStatus;

    public CustomException(HttpStatus httpStatus) {
        this.httpStatus = httpStatus;
    }

    public CustomException(HttpStatus httpStatus, String message) {
        super(message);
        this.httpStatus = httpStatus;
    }

    public CustomException updateHttpStatus(HttpStatus httpStatus) {
        this.httpStatus = httpStatus;

        return this;
    }
  }
  ```

### `GeneralExceptionType`에서 공통 타입의 예외를 관리
- [x] `예외를 공통 타입으로 도 묶을 수 있어야 한다` 만족
- [x] `예외는 확장 가능해야 한다` -> 메서드 오버로딩으로 매개변수가 다른 동일한 타입의 예외를 만들 수 있다.

  ```java
  public class GeneralExceptionType {

    /**
     * 일반적인 예외 상황에 사용되는 예외입니다.
     * <p>
     * 다른 패키지에 정의될 예외 중 공통 타입으로 묶이지 않는 예외는 이 GENERAL_EXCEPTION을 상속 받으면 됩니다.
     *
     * @param httpStatus HTTP 상태 코드
     * @param message 예외에 대한 메시지
     * @return CustomException 객체
     */
    public static CustomException GENERAL_EXCEPTION(HttpStatus httpStatus, String message) {
        return new CustomException(httpStatus, message);
    }

    /**
     * 어떤 도메인 클래스를 찾을 수 없을 때 사용되는 예외입니다.
     *
     * @param domainClazz 찾을 수 없는 도메인 클래스
     * @return CustomException 객체
     */
    public static CustomException DOMAIN_NOT_FOUND_EXCEPTION(Class<?> domainClazz) {
        return new CustomException(
                HttpStatus.NOT_FOUND,
                String.format("[%s] 도메인을 찾을 수 없습니다.", domainClazz.getSimpleName())
        );
    }

    /**
     * 주어진 ID를 가진 도메인 객체를 찾을 수 없을 때 사용되는 예외입니다.
     *
     * @param domainClazz 찾을 수 없는 도메인 클래스
     * @param domainId 찾을 수 없는 도메인 객체의 ID
     * @return CustomException 객체
     */
    public static CustomException DOMAIN_NOT_FOUND_EXCEPTION(Class<?> domainClazz, Long domainId) {
        return new CustomException(
                HttpStatus.NOT_FOUND,
                String.format("[id = %d]에 해당하는 [%s] 도메인을 찾을 수 없습니다.", domainId, domainClazz.getSimpleName())
        );
    }
    // ... 생략
  }
  ```

### 도메인별 ExceptionType에 도메인별 예외를 생성하는 메서드를 구현
- [x] `같은 도메인의 예외들 끼리 Enum으로 한 곳에서 관리하고 싶다` -> Enum은 아니지만 같은 도메인 예외끼리 한 곳에서 관리 가능

  ```java
  public class MemberExceptionType extends GeneralExceptionType {

    public static CustomException MEMBER_NOT_FOUND_EXCEPTION() {
        return DOMAIN_NOT_FOUND_EXCEPTION(Member.class);
    }

    public static CustomException MEMBER_NOT_FOUND_EXCEPTION(Long domainId) {
        return DOMAIN_NOT_FOUND_EXCEPTION(Member.class, domainId);
    }

    public static CustomException NO_SUCH_OAUTH_PLATFORM_TYPE_EXCEPTION(String mismatchedTypeName) {
        return NO_SUCH_ENUM_TYPE_EXCEPTION(OAuthPlatformType.class, mismatchedTypeName);
    }

  }
  ```

### 예외 사용법
- 코드가 너무 길어져서 `import static`를 사용하는게 좋을 것 같습니다.
  ```java
  import static ...MemberExceptionType.MEMBER_NOT_FOUND_EXCEPTION;
  
  // ... 생략
  
  Long memberId = 1L;
  Member member = repository.findById(memberId)
      .orElseThrow(() -> MEMBER_NOT_FOUND_EXCEPTION(memberId))
  ```

