### PR TITLE
[test] 스터디 가입 요청/수락/거절 API 인수 테스트 추가

### DIFF
--- a/src/main/java/com/flytrap/venusplanner/VenusPlannerApplication.java
+++ b/src/main/java/com/flytrap/venusplanner/VenusPlannerApplication.java
@@ -3,11 +3,9 @@ package com.flytrap.venusplanner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
-@EnableJpaAuditing
 public class VenusPlannerApplication {
 
     public static void main(String[] args) {

--- a/src/test/java/com/flytrap/venusplanner/acceptance/AcceptanceTest.java
+++ b/src/test/java/com/flytrap/venusplanner/acceptance/AcceptanceTest.java
@@ -14,6 +14,8 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.jdbc.Sql;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -22,6 +24,14 @@ public abstract class AcceptanceTest {
 
     @LocalServerPort
     private int port;
+
+    static {
+        GenericContainer<?> redis =
+                new GenericContainer<>(DockerImageName.parse("redis:latest")).withExposedPorts(6379);
+        redis.start();
+        System.setProperty("spring.data.redis.host", redis.getHost());
+        System.setProperty("spring.data.redis.port", redis.getMappedPort(6379).toString());
+    }
 
     @BeforeAll
     void setUp() {

--- a/src/test/java/com/flytrap/venusplanner/acceptance/AcceptanceTest.java
+++ b/src/test/java/com/flytrap/venusplanner/acceptance/AcceptanceTest.java
@@ -6,7 +6,8 @@ import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -15,18 +16,17 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.jdbc.Sql;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Sql("classpath:reset.sql")
 public abstract class AcceptanceTest {
 
     @LocalServerPort
     private int port;
 
-    @BeforeEach
+    @BeforeAll
     void setUp() {
         RestAssured.port = port;
     }
-
-    // TODO:로그인 로직
 
     protected static RequestSpecification givenJsonRequest() {
         return RestAssured.given().log().all()
@@ -34,7 +34,27 @@ public abstract class AcceptanceTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE);
     }
 
-    protected void 응답_상태코드_검증(ExtractableResponse<Response> response, HttpStatus httpStatus) {
+    protected void 응답_코드는_200_OK_를_반환한다(ExtractableResponse<Response> response) {
+        응답_상태코드_검증(response, HttpStatus.OK);
+    }
+
+    protected void 응답_코드는_201_CREATED_를_반환한다(ExtractableResponse<Response> response) {
+        응답_상태코드_검증(response, HttpStatus.CREATED);
+    }
+
+    protected void 응답_코드는_403_FORBIDDEN_를_반환한다(ExtractableResponse<Response> response) {
+        응답_상태코드_검증(response, HttpStatus.FORBIDDEN);
+    }
+
+    protected void 응답_코드는_404_NOT_FOUND_를_반환한다(ExtractableResponse<Response> response) {
+        응답_상태코드_검증(response, HttpStatus.NOT_FOUND);
+    }
+
+    protected void 응답_코드는_409_CONFLICT_를_반환한다(ExtractableResponse<Response> response) {
+        응답_상태코드_검증(response, HttpStatus.CONFLICT);
+    }
+
+    private void 응답_상태코드_검증(ExtractableResponse<Response> response, HttpStatus httpStatus) {
         assertThat(response.statusCode()).isEqualTo(httpStatus.value());
     }
 }

--- a/src/test/java/com/flytrap/venusplanner/acceptance/AcceptanceTest.java
+++ b/src/test/java/com/flytrap/venusplanner/acceptance/AcceptanceTest.java
@@ -1,4 +1,4 @@
-package com.flytrap.venusplanner.global;
+package com.flytrap.venusplanner.acceptance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/com/flytrap/venusplanner/acceptance/AcceptanceTest.java
+++ b/src/test/java/com/flytrap/venusplanner/acceptance/AcceptanceTest.java
@@ -69,6 +69,10 @@ public abstract class AcceptanceTest {
         응답_상태코드_검증(response, HttpStatus.CREATED);
     }
 
+    protected void 응답_코드는_400_BAD_REQUEST_를_반환한다(ExtractableResponse<Response> response) {
+        응답_상태코드_검증(response, HttpStatus.BAD_REQUEST);
+    }
+
     protected void 응답_코드는_403_FORBIDDEN_를_반환한다(ExtractableResponse<Response> response) {
         응답_상태코드_검증(response, HttpStatus.FORBIDDEN);
     }

--- a/src/test/java/com/flytrap/venusplanner/acceptance/common/SessionCookie.java
+++ b/src/test/java/com/flytrap/venusplanner/acceptance/common/SessionCookie.java
@@ -1,0 +1,7 @@
+package com.flytrap.venusplanner.acceptance.common;
+
+public record SessionCookie(
+        String name,
+        String value
+) {
+}

--- a/src/test/java/com/flytrap/venusplanner/acceptance/common/TestAuthMemberController.java
+++ b/src/test/java/com/flytrap/venusplanner/acceptance/common/TestAuthMemberController.java
@@ -1,0 +1,20 @@
+package com.flytrap.venusplanner.acceptance.common;
+
+import com.flytrap.venusplanner.global.auth.dto.SessionMember;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class TestAuthMemberController {
+
+    @Value("${auth.session.sessionName}")
+    private String sessionName;
+
+    @PostMapping("/api/v1/test/sign-in")
+    public void signIn(@RequestBody Long memberId, HttpSession session) {
+        session.setAttribute(sessionName, new SessionMember(memberId));
+    }
+}

--- a/src/test/java/com/flytrap/venusplanner/acceptance/join_request/fixture/JoinRequestFixture.java
+++ b/src/test/java/com/flytrap/venusplanner/acceptance/join_request/fixture/JoinRequestFixture.java
@@ -35,6 +35,10 @@ public class JoinRequestFixture {
         return new Study("알고리즘 챌린지", "알고리즘 실력을 쌓아갑니다.");
     }
 
+    public static Study 파이썬_스터디() {
+        return new Study("Python 스터디", "최신 Python 트렌드를 공부하며 프로젝트를 함께 진행합니다.");
+    }
+
     public static MemberStudy 리더_멤버_스터디(Study study, Member leader) {
         return MemberStudy.fromLeader(leader.getId(), study);
     }

--- a/src/test/java/com/flytrap/venusplanner/acceptance/join_request/fixture/JoinRequestFixture.java
+++ b/src/test/java/com/flytrap/venusplanner/acceptance/join_request/fixture/JoinRequestFixture.java
@@ -1,0 +1,70 @@
+package com.flytrap.venusplanner.acceptance.join_request.fixture;
+
+import com.flytrap.venusplanner.api.access.domain.Permission;
+import com.flytrap.venusplanner.api.access.domain.Roll;
+import com.flytrap.venusplanner.api.join_request.domain.JoinRequest;
+import com.flytrap.venusplanner.api.join_request.domain.JoinRequestState;
+import com.flytrap.venusplanner.api.member.domain.Member;
+import com.flytrap.venusplanner.api.member.domain.OAuthPlatformType;
+import com.flytrap.venusplanner.api.member_study.domain.MemberStudy;
+import com.flytrap.venusplanner.api.study.domain.Study;
+
+public class JoinRequestFixture {
+
+    public static Member 리더() {
+        return Member.builder()
+                .oauthPk("00000")
+                .oauthPlatformId(OAuthPlatformType.GITHUB.getId())
+                .email("leader@venus.test")
+                .nickname("leader")
+                .profileImageUrl("https://test.com")
+                .build();
+    }
+
+    public static Member 멤버_01() {
+        return Member.builder()
+                .oauthPk("11111")
+                .oauthPlatformId(OAuthPlatformType.GITHUB.getId())
+                .email("member01@venus.test")
+                .nickname("member01")
+                .profileImageUrl("https://test.com")
+                .build();
+    }
+
+    public static Study 알고리즘_스터디() {
+        return new Study("알고리즘 챌린지", "알고리즘 실력을 쌓아갑니다.");
+    }
+
+    public static MemberStudy 리더_멤버_스터디(Study study, Member leader) {
+        return MemberStudy.fromLeader(leader.getId(), study);
+    }
+
+    public static MemberStudy 멤버_스터디(Study study, Member member) {
+        return MemberStudy.builder()
+                .memberId(member.getId())
+                .study(study)
+                .rollId(Roll.MEMBER.getId())
+                .permissionId(Permission.NONE.getId())
+                .build();
+    }
+
+    public static JoinRequest 신규_가입_요청(Study study, Member member) {
+        return JoinRequest.create(study.getId(), member.getId());
+    }
+
+    public static JoinRequest 수락된_가입_요청(Study study, Member member) {
+        return JoinRequest.builder()
+                .studyId(study.getId())
+                .memberId(member.getId())
+                .state(JoinRequestState.ACCEPT)
+                .build();
+    }
+
+    public static JoinRequest 거절된_가입_요청(Study study, Member member) {
+        return JoinRequest.builder()
+                .studyId(study.getId())
+                .memberId(member.getId())
+                .state(JoinRequestState.REJECT)
+                .build();
+    }
+}

--- a/src/test/java/com/flytrap/venusplanner/acceptance/join_request/step/JoinRequestStep.java
+++ b/src/test/java/com/flytrap/venusplanner/acceptance/join_request/step/JoinRequestStep.java
@@ -1,0 +1,31 @@
+package com.flytrap.venusplanner.acceptance.join_request.step;
+
+import com.flytrap.venusplanner.acceptance.AcceptanceTest;
+import com.flytrap.venusplanner.acceptance.common.SessionCookie;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+public class JoinRequestStep extends AcceptanceTest {
+
+    public static ExtractableResponse<Response> 스터디_가입_요청(Long studyId, SessionCookie sessionCookie) {
+        return givenJsonRequest()
+                .cookie(sessionCookie.name(), sessionCookie.value())
+                .when().post("/api/v1/studies/{studyId}/join-requests", studyId)
+                .then().log().all().extract();
+    }
+
+    public static ExtractableResponse<Response> 스터디_가입_요청_수락(Long studyId, Long requestId, SessionCookie sessionCookie) {
+        return givenJsonRequest()
+                .cookie(sessionCookie.name(), sessionCookie.value())
+                .when().post("/api/v1/studies/{studyId}/join-requests/{requestId}/accept", studyId, requestId)
+                .then().log().all().extract();
+    }
+
+    public static ExtractableResponse<Response> 스터디_가입_요청_거절(Long studyId, Long requestId, SessionCookie sessionCookie) {
+        return givenJsonRequest()
+                .cookie(sessionCookie.name(), sessionCookie.value())
+                .when().post("/api/v1/studies/{studyId}/join-requests/{requestId}/reject", studyId, requestId)
+                .then().log().all().extract();
+    }
+
+}

--- a/src/test/java/com/flytrap/venusplanner/acceptance/join_request/step/JoinRequestStep.java
+++ b/src/test/java/com/flytrap/venusplanner/acceptance/join_request/step/JoinRequestStep.java
@@ -17,14 +17,14 @@ public class JoinRequestStep extends AcceptanceTest {
     public static ExtractableResponse<Response> 스터디_가입_요청_수락(Long studyId, Long requestId, SessionCookie sessionCookie) {
         return givenJsonRequest()
                 .cookie(sessionCookie.name(), sessionCookie.value())
-                .when().post("/api/v1/studies/{studyId}/join-requests/{requestId}/accept", studyId, requestId)
+                .when().patch("/api/v1/studies/{studyId}/join-requests/{requestId}/accept", studyId, requestId)
                 .then().log().all().extract();
     }
 
     public static ExtractableResponse<Response> 스터디_가입_요청_거절(Long studyId, Long requestId, SessionCookie sessionCookie) {
         return givenJsonRequest()
                 .cookie(sessionCookie.name(), sessionCookie.value())
-                .when().post("/api/v1/studies/{studyId}/join-requests/{requestId}/reject", studyId, requestId)
+                .when().patch("/api/v1/studies/{studyId}/join-requests/{requestId}/reject", studyId, requestId)
                 .then().log().all().extract();
     }
 

--- a/src/test/java/com/flytrap/venusplanner/acceptance/join_request/test/AcceptJoinRequestTest.java
+++ b/src/test/java/com/flytrap/venusplanner/acceptance/join_request/test/AcceptJoinRequestTest.java
@@ -1,0 +1,125 @@
+package com.flytrap.venusplanner.acceptance.join_request.test;
+
+import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.거절된_가입_요청;
+import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.리더;
+import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.리더_멤버_스터디;
+import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.멤버_01;
+import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.수락된_가입_요청;
+import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.신규_가입_요청;
+import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.알고리즘_스터디;
+import static com.flytrap.venusplanner.acceptance.join_request.step.JoinRequestStep.스터디_가입_요청_수락;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.flytrap.venusplanner.acceptance.AcceptanceTest;
+import com.flytrap.venusplanner.api.join_request.domain.JoinRequest;
+import com.flytrap.venusplanner.api.join_request.domain.JoinRequestState;
+import com.flytrap.venusplanner.api.join_request.infrastructure.repository.JoinRequestRepository;
+import com.flytrap.venusplanner.api.member.infrastructure.repository.MemberRepository;
+import com.flytrap.venusplanner.api.member_study.infrastructure.repository.MemberStudyRepository;
+import com.flytrap.venusplanner.api.study.infrastructure.repository.StudyRepository;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("[인수테스트] 스터디 가입 요청 수락 케이스")
+public class AcceptJoinRequestTest extends AcceptanceTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    StudyRepository studyRepository;
+
+    @Autowired
+    MemberStudyRepository memberStudyRepository;
+
+    @Autowired
+    JoinRequestRepository joinRequestRepository;
+
+    @Test
+    void 스터디_리더는_스터디_가입_요청을_수락_할_수_있다() {
+        // given
+        var leader = memberRepository.save(리더());
+        var member = memberRepository.save(멤버_01());
+        var study = studyRepository.save(알고리즘_스터디());
+        var leaderMemberStudy = memberStudyRepository.save(리더_멤버_스터디(study, leader));
+        var joinRequest = joinRequestRepository.save(신규_가입_요청(study, member));
+        var sessionCookie = 테스트_로그인(leader.getId());
+
+        // when
+        var response = 스터디_가입_요청_수락(
+                study.getId(), joinRequest.getId(), sessionCookie);
+
+        // then
+        응답_코드는_200_OK_를_반환한다(response);
+        응답_바디로_빈_응답을_반환한다(response);
+        스터디_가입_요청이_수락_되었는지_검증(joinRequest);
+    }
+
+    @Test
+    void 스터디_리더가_아닌_멤버는_스터디_가입_요청을_수락_할_수_없다() {
+        // given
+        var leader = memberRepository.save(리더());
+        var member = memberRepository.save(멤버_01());
+        var study = studyRepository.save(알고리즘_스터디());
+        var leaderMemberStudy = memberStudyRepository.save(리더_멤버_스터디(study, leader));
+        var joinRequest = joinRequestRepository.save(신규_가입_요청(study, member));
+        var sessionCookie = 테스트_로그인(member.getId());
+
+        // when
+        var response = 스터디_가입_요청_수락(
+                study.getId(), joinRequest.getId(), sessionCookie);
+
+        // then
+        응답_코드는_403_FORBIDDEN_를_반환한다(response);
+    }
+
+    @Test
+    void 이미_수락된_스터디_가입_요청은_수락_할_수_없다() {
+        // given
+        var leader = memberRepository.save(리더());
+        var member = memberRepository.save(멤버_01());
+        var study = studyRepository.save(알고리즘_스터디());
+        var leaderMemberStudy = memberStudyRepository.save(리더_멤버_스터디(study, leader));
+        var joinRequest = joinRequestRepository.save(수락된_가입_요청(study, member));
+        var sessionCookie = 테스트_로그인(leader.getId());
+
+        // when
+        var response = 스터디_가입_요청_수락(
+                study.getId(), joinRequest.getId(), sessionCookie);
+
+        // then
+        응답_코드는_409_CONFLICT_를_반환한다(response);
+    }
+
+    @Test
+    void 이미_거절된_스터디_가입_요청은_수락_할_수_없다() {
+        // given
+        var leader = memberRepository.save(리더());
+        var member = memberRepository.save(멤버_01());
+        var study = studyRepository.save(알고리즘_스터디());
+        var leaderMemberStudy = memberStudyRepository.save(리더_멤버_스터디(study, leader));
+        var joinRequest = joinRequestRepository.save(거절된_가입_요청(study, member));
+        var sessionCookie = 테스트_로그인(leader.getId());
+
+        // when
+        var response = 스터디_가입_요청_수락(
+                study.getId(), joinRequest.getId(), sessionCookie);
+
+        // then
+        응답_코드는_409_CONFLICT_를_반환한다(response);
+    }
+
+    private void 응답_바디로_빈_응답을_반환한다(ExtractableResponse<Response> response) {
+        assertThat(response.body().asString()).isEmpty();
+    }
+
+    private void 스터디_가입_요청이_수락_되었는지_검증(JoinRequest joinRequest) {
+        var created = joinRequestRepository.findById(joinRequest.getId()).get();
+
+        assertThat(created.getState()).isEqualTo(JoinRequestState.ACCEPT);
+    }
+
+}

--- a/src/test/java/com/flytrap/venusplanner/acceptance/join_request/test/AcceptJoinRequestTest.java
+++ b/src/test/java/com/flytrap/venusplanner/acceptance/join_request/test/AcceptJoinRequestTest.java
@@ -7,6 +7,7 @@ import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinReque
 import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.수락된_가입_요청;
 import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.신규_가입_요청;
 import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.알고리즘_스터디;
+import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.파이썬_스터디;
 import static com.flytrap.venusplanner.acceptance.join_request.step.JoinRequestStep.스터디_가입_요청_수락;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -110,6 +111,26 @@ public class AcceptJoinRequestTest extends AcceptanceTest {
 
         // then
         응답_코드는_409_CONFLICT_를_반환한다(response);
+    }
+
+    @Test
+    void 가입_요청시_URL의_JOIN_REQUEST가_STUDY에_포함되지_않으면_가입_요청은_수락_할_수_없다() {
+        // given
+        var leader = memberRepository.save(리더());
+        var member = memberRepository.save(멤버_01());
+        var algorithmStudy = studyRepository.save(알고리즘_스터디());
+        var pythonStudy = studyRepository.save(파이썬_스터디());
+        var algorithmMemberStudyLeader = memberStudyRepository.save(리더_멤버_스터디(algorithmStudy, leader));
+        var pythonMemberStudyLeader = memberStudyRepository.save(리더_멤버_스터디(pythonStudy, leader));
+        var joinRequest = joinRequestRepository.save(신규_가입_요청(algorithmStudy, member));
+        var sessionCookie = 테스트_로그인(leader.getId());
+
+        // when
+        var response = 스터디_가입_요청_수락(
+                pythonStudy.getId(), joinRequest.getId(), sessionCookie);
+
+        // then
+        응답_코드는_400_BAD_REQUEST_를_반환한다(response);
     }
 
     private void 응답_바디로_빈_응답을_반환한다(ExtractableResponse<Response> response) {

--- a/src/test/java/com/flytrap/venusplanner/acceptance/join_request/test/AcceptJoinRequestTest.java
+++ b/src/test/java/com/flytrap/venusplanner/acceptance/join_request/test/AcceptJoinRequestTest.java
@@ -1,14 +1,14 @@
 package com.flytrap.venusplanner.acceptance.join_request.test;
 
-import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.거절된_가입_요청;
-import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.리더;
-import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.리더_멤버_스터디;
-import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.멤버_01;
-import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.수락된_가입_요청;
-import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.신규_가입_요청;
-import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.알고리즘_스터디;
-import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.파이썬_스터디;
 import static com.flytrap.venusplanner.acceptance.join_request.step.JoinRequestStep.스터디_가입_요청_수락;
+import static com.flytrap.venusplanner.global.fixture.JoinRequestFixture.거절된_가입_요청;
+import static com.flytrap.venusplanner.global.fixture.JoinRequestFixture.수락된_가입_요청;
+import static com.flytrap.venusplanner.global.fixture.JoinRequestFixture.신규_가입_요청;
+import static com.flytrap.venusplanner.global.fixture.MemberFixture.리더;
+import static com.flytrap.venusplanner.global.fixture.MemberFixture.멤버_01;
+import static com.flytrap.venusplanner.global.fixture.MemberStudyFixture.리더_멤버_스터디;
+import static com.flytrap.venusplanner.global.fixture.StudyFixture.알고리즘_스터디;
+import static com.flytrap.venusplanner.global.fixture.StudyFixture.파이썬_스터디;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.flytrap.venusplanner.acceptance.AcceptanceTest;

--- a/src/test/java/com/flytrap/venusplanner/acceptance/join_request/test/CreateJoinRequestTest.java
+++ b/src/test/java/com/flytrap/venusplanner/acceptance/join_request/test/CreateJoinRequestTest.java
@@ -1,13 +1,13 @@
 package com.flytrap.venusplanner.acceptance.join_request.test;
 
-import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.리더;
-import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.리더_멤버_스터디;
-import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.멤버_01;
-import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.멤버_스터디;
-import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.수락된_가입_요청;
-import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.신규_가입_요청;
-import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.알고리즘_스터디;
 import static com.flytrap.venusplanner.acceptance.join_request.step.JoinRequestStep.스터디_가입_요청;
+import static com.flytrap.venusplanner.global.fixture.JoinRequestFixture.수락된_가입_요청;
+import static com.flytrap.venusplanner.global.fixture.JoinRequestFixture.신규_가입_요청;
+import static com.flytrap.venusplanner.global.fixture.MemberFixture.리더;
+import static com.flytrap.venusplanner.global.fixture.MemberFixture.멤버_01;
+import static com.flytrap.venusplanner.global.fixture.MemberStudyFixture.리더_멤버_스터디;
+import static com.flytrap.venusplanner.global.fixture.MemberStudyFixture.멤버_스터디;
+import static com.flytrap.venusplanner.global.fixture.StudyFixture.알고리즘_스터디;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 

--- a/src/test/java/com/flytrap/venusplanner/acceptance/join_request/test/CreateJoinRequestTest.java
+++ b/src/test/java/com/flytrap/venusplanner/acceptance/join_request/test/CreateJoinRequestTest.java
@@ -1,0 +1,125 @@
+package com.flytrap.venusplanner.acceptance.join_request.test;
+
+import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.리더;
+import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.리더_멤버_스터디;
+import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.멤버_01;
+import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.멤버_스터디;
+import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.수락된_가입_요청;
+import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.신규_가입_요청;
+import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.알고리즘_스터디;
+import static com.flytrap.venusplanner.acceptance.join_request.step.JoinRequestStep.스터디_가입_요청;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.flytrap.venusplanner.acceptance.AcceptanceTest;
+import com.flytrap.venusplanner.api.join_request.domain.JoinRequestState;
+import com.flytrap.venusplanner.api.join_request.infrastructure.repository.JoinRequestRepository;
+import com.flytrap.venusplanner.api.member.domain.Member;
+import com.flytrap.venusplanner.api.member.infrastructure.repository.MemberRepository;
+import com.flytrap.venusplanner.api.member_study.infrastructure.repository.MemberStudyRepository;
+import com.flytrap.venusplanner.api.study.domain.Study;
+import com.flytrap.venusplanner.api.study.infrastructure.repository.StudyRepository;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("[인수테스트] 스터디 가입 요청 케이스")
+public class CreateJoinRequestTest extends AcceptanceTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    StudyRepository studyRepository;
+
+    @Autowired
+    MemberStudyRepository memberStudyRepository;
+
+    @Autowired
+    JoinRequestRepository joinRequestRepository;
+
+    @Test
+    void 유저는_스터디에_가입_요청을_할_수_있다() {
+        // given
+        var leader = memberRepository.save(리더());
+        var member = memberRepository.save(멤버_01());
+        var study = studyRepository.save(알고리즘_스터디());
+        var leaderMemberStudy = memberStudyRepository.save(리더_멤버_스터디(study, leader));
+        var sessionCookie = 테스트_로그인(member.getId());
+
+        // when
+        var response = 스터디_가입_요청(study.getId(), sessionCookie);
+
+        // then
+        응답_코드는_201_CREATED_를_반환한다(response);
+        응답_바디로_생성된_가입_요청의_ID를_반환한다(response);
+        스터디_가입_요청이_생성되었는지_검증(response, study, member);
+    }
+
+    @Test
+    void 존재하지_않는_스터디에_가입_요청을_보낼_수_없다() {
+        // given
+        var member = memberRepository.save(멤버_01());
+        var sessionCookie = 테스트_로그인(member.getId());
+
+        // when
+        var response = 스터디_가입_요청(999L, sessionCookie);
+
+        // then
+        응답_코드는_404_NOT_FOUND_를_반환한다(response);
+    }
+
+    @Test
+    void 이미_가입_요청된_상태의_스터디에_가입_요청을_보낼_수_없다() {
+        // given
+        var leader = memberRepository.save(리더());
+        var member = memberRepository.save(멤버_01());
+        var study = studyRepository.save(알고리즘_스터디());
+        var leaderMemberStudy = memberStudyRepository.save(리더_멤버_스터디(study, leader));
+        var joinRequest = joinRequestRepository.save(신규_가입_요청(study, member));
+        var sessionCookie = 테스트_로그인(member.getId());
+
+        // when
+        var response = 스터디_가입_요청(study.getId(), sessionCookie);
+
+        // then
+        응답_코드는_409_CONFLICT_를_반환한다(response);
+    }
+
+    @Test
+    void 이미_가입된_스터디에_가입_요청을_보낼_수_없다() {
+        // given
+        var leader = memberRepository.save(리더());
+        var member = memberRepository.save(멤버_01());
+        var study = studyRepository.save(알고리즘_스터디());
+        var leaderMemberStudy = memberStudyRepository.save(리더_멤버_스터디(study, leader));
+        var memberStudy = memberStudyRepository.save(멤버_스터디(study, member));
+        var joinRequest = joinRequestRepository.save(수락된_가입_요청(study, member));
+        var sessionCookie = 테스트_로그인(member.getId());
+
+        // when
+        var response = 스터디_가입_요청(study.getId(), sessionCookie);
+
+        // then
+        응답_코드는_409_CONFLICT_를_반환한다(response);
+    }
+
+    private void 응답_바디로_생성된_가입_요청의_ID를_반환한다(ExtractableResponse<Response> response) {
+        assertThat(response.body().jsonPath().getLong("id"))
+                .isNotNull();
+    }
+
+    private void 스터디_가입_요청이_생성되었는지_검증(ExtractableResponse<Response> response, Study study, Member member) {
+        var createdId = response.body().jsonPath().getLong("id");
+        var created = joinRequestRepository.findById(createdId).get();
+
+        assertAll(
+                () -> assertThat(created.getStudyId()).isEqualTo(study.getId()),
+                () -> assertThat(created.getMemberId()).isEqualTo(member.getId()),
+                () -> assertThat(created.getState()).isEqualTo(JoinRequestState.WAIT)
+        );
+    }
+
+}

--- a/src/test/java/com/flytrap/venusplanner/acceptance/join_request/test/RejectJoinRequestTest.java
+++ b/src/test/java/com/flytrap/venusplanner/acceptance/join_request/test/RejectJoinRequestTest.java
@@ -7,6 +7,7 @@ import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinReque
 import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.수락된_가입_요청;
 import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.신규_가입_요청;
 import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.알고리즘_스터디;
+import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.파이썬_스터디;
 import static com.flytrap.venusplanner.acceptance.join_request.step.JoinRequestStep.스터디_가입_요청_거절;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -110,6 +111,26 @@ public class RejectJoinRequestTest extends AcceptanceTest {
 
         // then
         응답_코드는_409_CONFLICT_를_반환한다(response);
+    }
+
+    @Test
+    void 가입_요청시_URL의_JOIN_REQUEST가_STUDY에_포함되지_않으면_가입_요청은_수락_할_수_없다() {
+        // given
+        var leader = memberRepository.save(리더());
+        var member = memberRepository.save(멤버_01());
+        var algorithmStudy = studyRepository.save(알고리즘_스터디());
+        var pythonStudy = studyRepository.save(파이썬_스터디());
+        var algorithmMemberStudyLeader = memberStudyRepository.save(리더_멤버_스터디(algorithmStudy, leader));
+        var pythonMemberStudyLeader = memberStudyRepository.save(리더_멤버_스터디(pythonStudy, leader));
+        var joinRequest = joinRequestRepository.save(신규_가입_요청(algorithmStudy, member));
+        var sessionCookie = 테스트_로그인(leader.getId());
+
+        // when
+        var response = 스터디_가입_요청_거절(
+                pythonStudy.getId(), joinRequest.getId(), sessionCookie);
+
+        // then
+        응답_코드는_400_BAD_REQUEST_를_반환한다(response);
     }
 
     private void 응답_바디로_빈_응답을_반환한다(ExtractableResponse<Response> response) {

--- a/src/test/java/com/flytrap/venusplanner/acceptance/join_request/test/RejectJoinRequestTest.java
+++ b/src/test/java/com/flytrap/venusplanner/acceptance/join_request/test/RejectJoinRequestTest.java
@@ -1,0 +1,125 @@
+package com.flytrap.venusplanner.acceptance.join_request.test;
+
+import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.거절된_가입_요청;
+import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.리더;
+import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.리더_멤버_스터디;
+import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.멤버_01;
+import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.수락된_가입_요청;
+import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.신규_가입_요청;
+import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.알고리즘_스터디;
+import static com.flytrap.venusplanner.acceptance.join_request.step.JoinRequestStep.스터디_가입_요청_거절;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.flytrap.venusplanner.acceptance.AcceptanceTest;
+import com.flytrap.venusplanner.api.join_request.domain.JoinRequest;
+import com.flytrap.venusplanner.api.join_request.domain.JoinRequestState;
+import com.flytrap.venusplanner.api.join_request.infrastructure.repository.JoinRequestRepository;
+import com.flytrap.venusplanner.api.member.infrastructure.repository.MemberRepository;
+import com.flytrap.venusplanner.api.member_study.infrastructure.repository.MemberStudyRepository;
+import com.flytrap.venusplanner.api.study.infrastructure.repository.StudyRepository;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("[인수테스트] 스터디 가입 요청 거절 케이스")
+public class RejectJoinRequestTest extends AcceptanceTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    StudyRepository studyRepository;
+
+    @Autowired
+    MemberStudyRepository memberStudyRepository;
+
+    @Autowired
+    JoinRequestRepository joinRequestRepository;
+
+    @Test
+    void 스터디_리더는_스터디_가입_요청을_거절_할_수_있다() {
+        // given
+        var leader = memberRepository.save(리더());
+        var member = memberRepository.save(멤버_01());
+        var study = studyRepository.save(알고리즘_스터디());
+        var leaderMemberStudy = memberStudyRepository.save(리더_멤버_스터디(study, leader));
+        var joinRequest = joinRequestRepository.save(신규_가입_요청(study, member));
+        var sessionCookie = 테스트_로그인(leader.getId());
+
+        // when
+        var response = 스터디_가입_요청_거절(
+                study.getId(), joinRequest.getId(), sessionCookie);
+
+        // then
+        응답_코드는_200_OK_를_반환한다(response);
+        응답_바디로_빈_응답을_반환한다(response);
+        스터디_가입_요청이_거절_되었는지_검증(joinRequest);
+    }
+
+    @Test
+    void 스터디_리더가_아닌_멤버는_스터디_가입_요청을_거절_할_수_없다() {
+        // given
+        var leader = memberRepository.save(리더());
+        var member = memberRepository.save(멤버_01());
+        var study = studyRepository.save(알고리즘_스터디());
+        var leaderMemberStudy = memberStudyRepository.save(리더_멤버_스터디(study, leader));
+        var joinRequest = joinRequestRepository.save(신규_가입_요청(study, member));
+        var sessionCookie = 테스트_로그인(member.getId());
+
+        // when
+        var response = 스터디_가입_요청_거절(
+                study.getId(), joinRequest.getId(), sessionCookie);
+
+        // then
+        응답_코드는_403_FORBIDDEN_를_반환한다(response);
+    }
+
+    @Test
+    void 이미_수락된_스터디_가입_요청은_거절_할_수_없다() {
+        // given
+        var leader = memberRepository.save(리더());
+        var member = memberRepository.save(멤버_01());
+        var study = studyRepository.save(알고리즘_스터디());
+        var leaderMemberStudy = memberStudyRepository.save(리더_멤버_스터디(study, leader));
+        var joinRequest = joinRequestRepository.save(수락된_가입_요청(study, member));
+        var sessionCookie = 테스트_로그인(leader.getId());
+
+        // when
+        var response = 스터디_가입_요청_거절(
+                study.getId(), joinRequest.getId(), sessionCookie);
+
+        // then
+        응답_코드는_409_CONFLICT_를_반환한다(response);
+    }
+
+    @Test
+    void 이미_거절된_스터디_가입_요청은_거절_할_수_없다() {
+        // given
+        var leader = memberRepository.save(리더());
+        var member = memberRepository.save(멤버_01());
+        var study = studyRepository.save(알고리즘_스터디());
+        var leaderMemberStudy = memberStudyRepository.save(리더_멤버_스터디(study, leader));
+        var joinRequest = joinRequestRepository.save(거절된_가입_요청(study, member));
+        var sessionCookie = 테스트_로그인(leader.getId());
+
+        // when
+        var response = 스터디_가입_요청_거절(
+                study.getId(), joinRequest.getId(), sessionCookie);
+
+        // then
+        응답_코드는_409_CONFLICT_를_반환한다(response);
+    }
+
+    private void 응답_바디로_빈_응답을_반환한다(ExtractableResponse<Response> response) {
+        assertThat(response.body().asString()).isEmpty();
+    }
+
+    private void 스터디_가입_요청이_거절_되었는지_검증(JoinRequest joinRequest) {
+        var created = joinRequestRepository.findById(joinRequest.getId()).get();
+
+        assertThat(created.getState()).isEqualTo(JoinRequestState.REJECT);
+    }
+
+}

--- a/src/test/java/com/flytrap/venusplanner/acceptance/join_request/test/RejectJoinRequestTest.java
+++ b/src/test/java/com/flytrap/venusplanner/acceptance/join_request/test/RejectJoinRequestTest.java
@@ -1,14 +1,14 @@
 package com.flytrap.venusplanner.acceptance.join_request.test;
 
-import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.거절된_가입_요청;
-import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.리더;
-import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.리더_멤버_스터디;
-import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.멤버_01;
-import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.수락된_가입_요청;
-import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.신규_가입_요청;
-import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.알고리즘_스터디;
-import static com.flytrap.venusplanner.acceptance.join_request.fixture.JoinRequestFixture.파이썬_스터디;
 import static com.flytrap.venusplanner.acceptance.join_request.step.JoinRequestStep.스터디_가입_요청_거절;
+import static com.flytrap.venusplanner.global.fixture.JoinRequestFixture.거절된_가입_요청;
+import static com.flytrap.venusplanner.global.fixture.JoinRequestFixture.수락된_가입_요청;
+import static com.flytrap.venusplanner.global.fixture.JoinRequestFixture.신규_가입_요청;
+import static com.flytrap.venusplanner.global.fixture.MemberFixture.리더;
+import static com.flytrap.venusplanner.global.fixture.MemberFixture.멤버_01;
+import static com.flytrap.venusplanner.global.fixture.MemberStudyFixture.리더_멤버_스터디;
+import static com.flytrap.venusplanner.global.fixture.StudyFixture.알고리즘_스터디;
+import static com.flytrap.venusplanner.global.fixture.StudyFixture.파이썬_스터디;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.flytrap.venusplanner.acceptance.AcceptanceTest;

--- a/src/test/java/com/flytrap/venusplanner/acceptance/join_request/test/RejectJoinRequestTest.java
+++ b/src/test/java/com/flytrap/venusplanner/acceptance/join_request/test/RejectJoinRequestTest.java
@@ -114,7 +114,7 @@ public class RejectJoinRequestTest extends AcceptanceTest {
     }
 
     @Test
-    void 가입_요청시_URL의_JOIN_REQUEST가_STUDY에_포함되지_않으면_가입_요청은_수락_할_수_없다() {
+    void 가입_요청시_URL의_JOIN_REQUEST가_STUDY에_포함되지_않으면_가입_요청은_거절_할_수_없다() {
         // given
         var leader = memberRepository.save(리더());
         var member = memberRepository.save(멤버_01());

--- a/src/test/java/com/flytrap/venusplanner/global/fixture/JoinRequestFixture.java
+++ b/src/test/java/com/flytrap/venusplanner/global/fixture/JoinRequestFixture.java
@@ -1,0 +1,29 @@
+package com.flytrap.venusplanner.global.fixture;
+
+import com.flytrap.venusplanner.api.join_request.domain.JoinRequest;
+import com.flytrap.venusplanner.api.join_request.domain.JoinRequestState;
+import com.flytrap.venusplanner.api.member.domain.Member;
+import com.flytrap.venusplanner.api.study.domain.Study;
+
+public class JoinRequestFixture {
+
+    public static JoinRequest 신규_가입_요청(Study study, Member member) {
+        return JoinRequest.create(study.getId(), member.getId());
+    }
+
+    public static JoinRequest 수락된_가입_요청(Study study, Member member) {
+        return JoinRequest.builder()
+                .studyId(study.getId())
+                .memberId(member.getId())
+                .state(JoinRequestState.ACCEPT)
+                .build();
+    }
+
+    public static JoinRequest 거절된_가입_요청(Study study, Member member) {
+        return JoinRequest.builder()
+                .studyId(study.getId())
+                .memberId(member.getId())
+                .state(JoinRequestState.REJECT)
+                .build();
+    }
+}

--- a/src/test/java/com/flytrap/venusplanner/global/fixture/MemberFixture.java
+++ b/src/test/java/com/flytrap/venusplanner/global/fixture/MemberFixture.java
@@ -1,0 +1,27 @@
+package com.flytrap.venusplanner.global.fixture;
+
+import com.flytrap.venusplanner.api.member.domain.Member;
+import com.flytrap.venusplanner.api.member.domain.OAuthPlatformType;
+
+public class MemberFixture {
+
+    public static Member 리더() {
+        return Member.builder()
+                .oauthPk("00000")
+                .oauthPlatformId(OAuthPlatformType.GITHUB.getId())
+                .email("leader@venus.test")
+                .nickname("leader")
+                .profileImageUrl("https://test.com")
+                .build();
+    }
+
+    public static Member 멤버_01() {
+        return Member.builder()
+                .oauthPk("11111")
+                .oauthPlatformId(OAuthPlatformType.GITHUB.getId())
+                .email("member01@venus.test")
+                .nickname("member01")
+                .profileImageUrl("https://test.com")
+                .build();
+    }
+}

--- a/src/test/java/com/flytrap/venusplanner/global/fixture/MemberStudyFixture.java
+++ b/src/test/java/com/flytrap/venusplanner/global/fixture/MemberStudyFixture.java
@@ -1,0 +1,22 @@
+package com.flytrap.venusplanner.global.fixture;
+
+import com.flytrap.venusplanner.api.access.domain.Permission;
+import com.flytrap.venusplanner.api.access.domain.Roll;
+import com.flytrap.venusplanner.api.member.domain.Member;
+import com.flytrap.venusplanner.api.member_study.domain.MemberStudy;
+import com.flytrap.venusplanner.api.study.domain.Study;
+
+public class MemberStudyFixture {
+    public static MemberStudy 리더_멤버_스터디(Study study, Member leader) {
+        return MemberStudy.fromLeader(leader.getId(), study);
+    }
+
+    public static MemberStudy 멤버_스터디(Study study, Member member) {
+        return MemberStudy.builder()
+                .memberId(member.getId())
+                .study(study)
+                .rollId(Roll.MEMBER.getId())
+                .permissionId(Permission.NONE.getId())
+                .build();
+    }
+}

--- a/src/test/java/com/flytrap/venusplanner/global/fixture/StudyFixture.java
+++ b/src/test/java/com/flytrap/venusplanner/global/fixture/StudyFixture.java
@@ -1,0 +1,14 @@
+package com.flytrap.venusplanner.global.fixture;
+
+import com.flytrap.venusplanner.api.study.domain.Study;
+
+public class StudyFixture {
+
+    public static Study 알고리즘_스터디() {
+        return new Study("알고리즘 챌린지", "알고리즘 실력을 쌓아갑니다.");
+    }
+
+    public static Study 파이썬_스터디() {
+        return new Study("Python 스터디", "최신 Python 트렌드를 공부하며 프로젝트를 함께 진행합니다.");
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -17,3 +17,7 @@ spring:
         show_sql: true
         format_sql: true
         highlight_sql: true
+
+auth:
+  session:
+    session-name: "login_session::"

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,3 +1,9 @@
+server:
+  servlet:
+    session:
+      cookie:
+        name: JSESSIONID
+
 spring:
   datasource:
     driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver

--- a/src/test/resources/reset.sql
+++ b/src/test/resources/reset.sql
@@ -11,3 +11,5 @@ TRUNCATE TABLE plan;
 TRUNCATE TABLE plan_category;
 
 TRUNCATE TABLE recurring_option;
+
+TRUNCATE TABLE join_request;


### PR DESCRIPTION
# ✨ Key changes
- [ ] #25   

# 👋 To reviewers
## Redis Test Container 추가
- 로그인 테스트를 위해 Redis Test Container를 추가했습니다.

## 테스트용 로그인 Step 메서드 구현
- Test에서만 사용할 로그인 Controller와 로그인 메서드를 만들었습니다.
- 단순히 session만 생성해 주는 기능입니다.
- @jinny-l 가 테스트용 로그인 API 구현하시면 변경될 수 도 있을 것 같아요

## 테스트 규칙 제안
### API 마다 테스트 class 만들기
  - e.g. `스터디 가입 요청 API` -> `CreateJoinRequestTest`
  - 변경이 일어난다면 API 단위가 될 것 같습니다. API 하나에 성공, 실패 시나리오가 다 있는 편이 요구사항 변경 시 수정해야할 파일 범위를 줄일 수 있다고 생각합니다. 또한 한 API만 수정했는데 다른 파일에서 에러가 나면 해당 변경사항이 다른 API까지 영향을 끼치고 있다는 것을 파일 이름으로 쉽게 파악할 수 있을 것 같습니다.

### Fixture는 해당 도메인에서만 사용하기
- 테스트 시나리오 마다 필요한 데이터와 상태가 다 다릅니다. 픽스처도 도메인의 시나리오 별로 관리하는게 코드는 많아져도 테스트를 이해하고 수정하는 것에는 덜 복잡해질 것 같아요.

## 테스트 케이스
### 스터디 가입 요청 케이스
- 유저는 스터디에 가입 요청을 할 수 있다
- 존재하지 않는 스터디에 가입 요청을 보낼 수 없다
- 이미 가입 요청된 상태의 스터디에 가입 요청을 보낼 수 없다
- 이미 가입된 스터디에 가입 요청을 보낼 수 없다

### 스터디 가입 요청 수락 케이스
- 스터디 리더는 스터디 가입 요청을 수락 할 수 있다
- 스터디 리더가 아닌 멤버는 스터디 가입 요청을 수락 할 수 없다
- 이미 수락된 스터디 가입 요청은 수락 할 수 없다
- 이미 거절된 스터디 가입 요청은 수락 할 수 없다
- 가입 요청시 URL의 JOIN REQUEST가 STUDY에 포함되지 않으면 가입 요청은 수락 할 수 없다

### 스터디 가입 요청 거절 케이스
- 스터디 리더는 스터디 가입 요청을 거절 할 수 있다
- 스터디 리더가 아닌 멤버는 스터디 가입 요청을 거절 할 수 없다
- 이미 수락된 스터디 가입 요청은 거절 할 수 없다
- 이미 거절된 스터디 가입 요청은 거절 할 수 없다
- 가입 요청시 URL의 JOIN REQUEST가 STUDY에 포함되지 않으면 가입 요청은 거절 할 수 없다
